### PR TITLE
Refactor plugin rendering

### DIFF
--- a/player/src/main/kotlin/io/clappr/player/components/Container.kt
+++ b/player/src/main/kotlin/io/clappr/player/components/Container.kt
@@ -8,6 +8,7 @@ import io.clappr.player.base.Options
 import io.clappr.player.base.UIObject
 import io.clappr.player.playback.NoOpPlayback
 import io.clappr.player.plugin.Plugin
+import io.clappr.player.plugin.container.UIContainerPlugin
 
 class Container(val loader: Loader, val options: Options) : UIObject() {
     val plugins: List<Plugin>
@@ -46,25 +47,22 @@ class Container(val loader: Loader, val options: Options) : UIObject() {
                 playback = null
             }
             supported = playback != null
+            render()
         }
         return supported
     }
 
     override fun render(): Container {
+        frameLayout.removeAllViews()
         val playback = this.playback
         playback?.let {
             frameLayout.addView(playback.view)
-            sendPlayBackViewToBack(playback)
             playback.render()
         }
+        plugins.filterIsInstance(UIContainerPlugin::class.java).forEach {
+            frameLayout.addView(it.view)
+            it.render()
+        }
         return this
-    }
-
-    private fun sendPlayBackViewToBack(playback: Playback) {
-        val playBackViewIndex = frameLayout.indexOfChild(playback.view)
-
-        var index = 0
-        while (index < playBackViewIndex)
-            frameLayout.getChildAt(index++).bringToFront()
     }
 }

--- a/player/src/main/kotlin/io/clappr/player/components/Core.kt
+++ b/player/src/main/kotlin/io/clappr/player/components/Core.kt
@@ -8,6 +8,7 @@ import io.clappr.player.plugin.Loader
 import io.clappr.player.base.Options
 import io.clappr.player.base.UIObject
 import io.clappr.player.plugin.Plugin
+import io.clappr.player.plugin.core.UICorePlugin
 
 class Core(val loader: Loader, val options: Options) : UIObject() {
     val plugins: List<Plugin>
@@ -48,8 +49,12 @@ class Core(val loader: Loader, val options: Options) : UIObject() {
 
     override fun render(): Core {
         containers.forEach {
-            it.render()
             frameLayout.addView(it.view)
+            it.render()
+        }
+        plugins.filterIsInstance(UICorePlugin::class.java).forEach {
+            frameLayout.addView(it.view)
+            it.render()
         }
         return this
     }

--- a/player/src/main/kotlin/io/clappr/player/plugin/LoadingPlugin.kt
+++ b/player/src/main/kotlin/io/clappr/player/plugin/LoadingPlugin.kt
@@ -15,7 +15,7 @@ import io.clappr.player.plugin.container.UIContainerPlugin
 
 open class LoadingPlugin(container: Container) : UIContainerPlugin(container) {
 
-    private var spinnerLayout: LinearLayout? = null
+    private var spinnerLayout: LinearLayout? = LinearLayout(context)
 
     companion object : NamedType {
         override val name = "spinner"
@@ -29,6 +29,14 @@ open class LoadingPlugin(container: Container) : UIContainerPlugin(container) {
                 stopListening()
             field = value
         }
+
+    override val view: View?
+        get() = spinnerLayout
+
+    init {
+        setupSpinnerLayout()
+        bindEventListeners()
+    }
 
     fun bindEventListeners() {
         listenTo(container, InternalEvent.DID_CHANGE_PLAYBACK.value, Callback.wrap { bindLoadingVisibilityCallBacks() })
@@ -48,32 +56,20 @@ open class LoadingPlugin(container: Container) : UIContainerPlugin(container) {
 
     private fun startAnimating(): Callback {
         return Callback.wrap {
-            if (spinnerLayout == null)
-                setupSpinner()
-
             spinnerLayout?.visibility = View.VISIBLE
             visibility = Visibility.VISIBLE
         }
     }
 
-    private fun setupSpinner() {
-        spinnerLayout = createSpinnerLayout()
-        spinnerLayout?.addView(ProgressBar(context))
+    private fun setupSpinnerLayout() {
+        spinnerLayout?.let {
+            it.layoutParams = LinearLayout.LayoutParams(LinearLayout.LayoutParams.MATCH_PARENT, LinearLayout.LayoutParams.MATCH_PARENT)
+            it.setGravity(Gravity.CENTER)
+            it.setBackgroundColor(ContextCompat.getColor(context, android.R.color.black))
+            it.alpha = 0.7f
 
-        container.frameLayout.addView(spinnerLayout)
-    }
-
-    private fun createSpinnerLayout(): LinearLayout {
-        val linearLayout = LinearLayout(context)
-        linearLayout.layoutParams = LinearLayout.LayoutParams(LinearLayout.LayoutParams.MATCH_PARENT, LinearLayout.LayoutParams.MATCH_PARENT)
-        linearLayout.setGravity(Gravity.CENTER)
-        linearLayout.setBackgroundColor(ContextCompat.getColor(context, android.R.color.black))
-        linearLayout.alpha = 0.7f
-        return linearLayout
-    }
-
-    init {
-        bindEventListeners()
+            it.addView(ProgressBar(context))
+        }
     }
 
     private fun stopAnimating(): Callback {

--- a/player/src/main/kotlin/io/clappr/player/plugin/UIPlugin.kt
+++ b/player/src/main/kotlin/io/clappr/player/plugin/UIPlugin.kt
@@ -1,5 +1,6 @@
 package io.clappr.player.plugin
 
+import android.view.View
 import io.clappr.player.base.BaseObject
 import io.clappr.player.base.EventInterface
 import io.clappr.player.base.UIObject
@@ -8,4 +9,11 @@ abstract class UIPlugin (component: BaseObject, private val uiObject: UIObject =
     enum class Visibility { HIDDEN, VISIBLE }
 
     var visibility = Visibility.HIDDEN
+
+    open val view: View?
+        get() = uiObject.view
+
+    open fun render() {
+        uiObject.render()
+    }
 }


### PR DESCRIPTION
Rendering plugins is one of Core/Container responsibilities, so instead of letting the plugin handle appending itself to the component view tree, their render method should be called when Core/Container are rendering themselves.