### PR TITLE
Plugin extensibility

### DIFF
--- a/clappr/src/main/kotlin/io/clappr/player/plugin/Loader.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/plugin/Loader.kt
@@ -131,7 +131,6 @@ class Loader(extraPlugins: List<KClass<out Plugin>> = emptyList(), extraPlayback
         try {
             plugin = constructor?.call(component) as? Plugin
         } catch (e: Exception) {
-            Log.e("Loader", "Exception when creating plugin $pluginClass: $e", e)
         }
 
         return plugin

--- a/clappr/src/main/kotlin/io/clappr/player/plugin/UIPlugin.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/plugin/UIPlugin.kt
@@ -8,7 +8,7 @@ import io.clappr.player.base.UIObject
 abstract class UIPlugin (component: BaseObject, private val uiObject: UIObject = UIObject()) : Plugin(component), EventInterface by uiObject {
     enum class Visibility { HIDDEN, VISIBLE }
 
-    var visibility = Visibility.HIDDEN
+    open var visibility = Visibility.HIDDEN
 
     open val view: View?
         get() = uiObject.view


### PR DESCRIPTION
Also removing invalid plugin error log on Loader as it is expected due to the lack of constructor component type (e.g.: load a Container plugin with a Core parameter).