### PR TITLE
Add load source events on container

### DIFF
--- a/clappr/src/main/kotlin/io/clappr/player/base/InternalEvents.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/base/InternalEvents.kt
@@ -10,5 +10,6 @@ enum class InternalEvent (val value: String) {
     WILL_ENTER_FULLSCREEN("willEnterFullscreen"),
     DID_ENTER_FULLSCREEN("didEnterFullscreen"),
     WILL_EXIT_FULLSCREEN("willExitFullscreen"),
-    DID_EXIT_FULLSCREEN("didExitFullscreen")
+    DID_EXIT_FULLSCREEN("didExitFullscreen"),
+    WILL_CHANGE_SOURCE("willChangeSource")
 }

--- a/clappr/src/main/kotlin/io/clappr/player/base/InternalEvents.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/base/InternalEvents.kt
@@ -12,5 +12,6 @@ enum class InternalEvent (val value: String) {
     WILL_EXIT_FULLSCREEN("willExitFullscreen"),
     DID_EXIT_FULLSCREEN("didExitFullscreen"),
     WILL_LOAD_SOURCE("willLoadSource"),
-    DID_LOAD_SOURCE("didLoadSource")
+    DID_LOAD_SOURCE("didLoadSource"),
+    DID_NOT_LOAD_SOURCE("didNotLoadSource")
 }

--- a/clappr/src/main/kotlin/io/clappr/player/base/InternalEvents.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/base/InternalEvents.kt
@@ -11,6 +11,6 @@ enum class InternalEvent (val value: String) {
     DID_ENTER_FULLSCREEN("didEnterFullscreen"),
     WILL_EXIT_FULLSCREEN("willExitFullscreen"),
     DID_EXIT_FULLSCREEN("didExitFullscreen"),
-    WILL_CHANGE_SOURCE("willChangeSource"),
-    DID_CHANGE_SOURCE("didChangeSource")
+    WILL_LOAD_SOURCE("willChangeSource"),
+    DID_LOAD_SOURCE("didChangeSource")
 }

--- a/clappr/src/main/kotlin/io/clappr/player/base/InternalEvents.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/base/InternalEvents.kt
@@ -11,6 +11,6 @@ enum class InternalEvent (val value: String) {
     DID_ENTER_FULLSCREEN("didEnterFullscreen"),
     WILL_EXIT_FULLSCREEN("willExitFullscreen"),
     DID_EXIT_FULLSCREEN("didExitFullscreen"),
-    WILL_LOAD_SOURCE("willChangeSource"),
-    DID_LOAD_SOURCE("didChangeSource")
+    WILL_LOAD_SOURCE("willLoadSource"),
+    DID_LOAD_SOURCE("didLoadSource")
 }

--- a/clappr/src/main/kotlin/io/clappr/player/base/InternalEvents.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/base/InternalEvents.kt
@@ -11,5 +11,6 @@ enum class InternalEvent (val value: String) {
     DID_ENTER_FULLSCREEN("didEnterFullscreen"),
     WILL_EXIT_FULLSCREEN("willExitFullscreen"),
     DID_EXIT_FULLSCREEN("didExitFullscreen"),
-    WILL_CHANGE_SOURCE("willChangeSource")
+    WILL_CHANGE_SOURCE("willChangeSource"),
+    DID_CHANGE_SOURCE("didChangeSource")
 }

--- a/clappr/src/main/kotlin/io/clappr/player/components/Container.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/components/Container.kt
@@ -40,6 +40,7 @@ class Container(val loader: Loader, val options: Options) : UIObject() {
     }
 
     fun load(source: String, mimeType: String? = null): Boolean {
+        trigger(InternalEvent.WILL_CHANGE_SOURCE.value)
         var supported = playback?.load(source, mimeType) ?: false
         if (!supported) {
             playback = loader.loadPlayback(source, mimeType, options)

--- a/clappr/src/main/kotlin/io/clappr/player/components/Container.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/components/Container.kt
@@ -52,7 +52,8 @@ class Container(val loader: Loader, val options: Options) : UIObject() {
             render()
         }
 
-        if (supported) trigger(InternalEvent.DID_LOAD_SOURCE.value)
+        val eventToTrigger = if (supported) InternalEvent.DID_LOAD_SOURCE else InternalEvent.DID_NOT_LOAD_SOURCE
+        trigger(eventToTrigger.value)
 
         return supported
     }

--- a/clappr/src/main/kotlin/io/clappr/player/components/Container.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/components/Container.kt
@@ -39,7 +39,7 @@ class Container(val loader: Loader, val options: Options) : UIObject() {
     }
 
     fun load(source: String, mimeType: String? = null): Boolean {
-        trigger(InternalEvent.WILL_CHANGE_SOURCE.value)
+        trigger(InternalEvent.WILL_LOAD_SOURCE.value)
 
         var supported = playback?.load(source, mimeType) ?: false
 
@@ -52,7 +52,7 @@ class Container(val loader: Loader, val options: Options) : UIObject() {
             render()
         }
 
-        if (supported) trigger(InternalEvent.DID_CHANGE_SOURCE.value)
+        if (supported) trigger(InternalEvent.DID_LOAD_SOURCE.value)
 
         return supported
     }

--- a/clappr/src/main/kotlin/io/clappr/player/components/Container.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/components/Container.kt
@@ -1,12 +1,11 @@
 package io.clappr.player.components
 
-import android.os.Build
 import android.widget.FrameLayout
 import io.clappr.player.base.InternalEvent
-import io.clappr.player.plugin.Loader
 import io.clappr.player.base.Options
 import io.clappr.player.base.UIObject
 import io.clappr.player.playback.NoOpPlayback
+import io.clappr.player.plugin.Loader
 import io.clappr.player.plugin.Plugin
 import io.clappr.player.plugin.container.UIContainerPlugin
 
@@ -41,7 +40,9 @@ class Container(val loader: Loader, val options: Options) : UIObject() {
 
     fun load(source: String, mimeType: String? = null): Boolean {
         trigger(InternalEvent.WILL_CHANGE_SOURCE.value)
+
         var supported = playback?.load(source, mimeType) ?: false
+
         if (!supported) {
             playback = loader.loadPlayback(source, mimeType, options)
             if (playback?.name == NoOpPlayback.name) {
@@ -50,6 +51,9 @@ class Container(val loader: Loader, val options: Options) : UIObject() {
             supported = playback != null
             render()
         }
+
+        if (supported) trigger(InternalEvent.DID_CHANGE_SOURCE.value)
+
         return supported
     }
 

--- a/clappr/src/test/kotlin/io/clappr/player/components/ContainerTest.kt
+++ b/clappr/src/test/kotlin/io/clappr/player/components/ContainerTest.kt
@@ -106,4 +106,49 @@ open class ContainerTest {
         container.load(source = "some_unknown_source.mp4")
         assertFalse("CHANGE_PLAYBACK triggered", callbackWasCalled)
     }
+
+    @Test
+    fun shouldTriggerLoadSourceEventsOnNewSource() {
+        Loader.registerPlayback(MP4Playback::class)
+        val container = Container(Loader(), Options("aSource.mp4"))
+
+        var willLoadWasCalled = false
+        var didLoadWasCalled = false
+        container.on(InternalEvent.WILL_LOAD_SOURCE.value, Callback.wrap { bundle: Bundle? -> willLoadWasCalled = true})
+        container.on(InternalEvent.DID_LOAD_SOURCE.value, Callback.wrap { bundle: Bundle? -> didLoadWasCalled = true })
+
+        container.load(source = "anotherSource.mp4")
+        assertTrue("Will Load Source was not called", willLoadWasCalled)
+        assertTrue("Did Load Source was not called", didLoadWasCalled)
+    }
+
+    @Test
+    fun shouldTriggerLoadSourceEventsOnSameSource() {
+        Loader.registerPlayback(MP4Playback::class)
+        val container = Container(Loader(), Options("aSource.mp4"))
+
+        var willLoadWasCalled = false
+        var didLoadWasCalled = false
+        container.on(InternalEvent.WILL_LOAD_SOURCE.value, Callback.wrap { bundle: Bundle? -> willLoadWasCalled = true})
+        container.on(InternalEvent.DID_LOAD_SOURCE.value, Callback.wrap { bundle: Bundle? -> didLoadWasCalled = true })
+
+        container.load(source = "aSource.mp4")
+        assertTrue("Will Load Source was not called", willLoadWasCalled)
+        assertTrue("Did Load Source was not called", didLoadWasCalled)
+    }
+
+    @Test
+    fun shouldNotTriggerDidLoadSourceEventsWhenNotSupported() {
+        Loader.registerPlayback(MP4Playback::class)
+        val container = Container(Loader(), Options("aSource.mp8"))
+
+        var willLoadWasCalled = false
+        var didLoadWasCalled = false
+        container.on(InternalEvent.WILL_LOAD_SOURCE.value, Callback.wrap { bundle: Bundle? -> willLoadWasCalled = true})
+        container.on(InternalEvent.DID_LOAD_SOURCE.value, Callback.wrap { bundle: Bundle? -> didLoadWasCalled = true })
+
+        container.load(source = "invalid_source.mp8")
+        assertTrue("Will Load Source was not called", willLoadWasCalled)
+        assertFalse("Did Load Source was called", didLoadWasCalled)
+    }
 }

--- a/clappr/src/test/kotlin/io/clappr/player/components/ContainerTest.kt
+++ b/clappr/src/test/kotlin/io/clappr/player/components/ContainerTest.kt
@@ -138,17 +138,21 @@ open class ContainerTest {
     }
 
     @Test
-    fun shouldNotTriggerDidLoadSourceEventsWhenNotSupported() {
+    fun shouldTriggerDidNotLoadSourceEventsWhenNotSupported() {
         Loader.registerPlayback(MP4Playback::class)
         val container = Container(Loader(), Options("aSource.mp8"))
 
         var willLoadWasCalled = false
         var didLoadWasCalled = false
+        var didNotLoadWasCalled = false
+
         container.on(InternalEvent.WILL_LOAD_SOURCE.value, Callback.wrap { bundle: Bundle? -> willLoadWasCalled = true})
         container.on(InternalEvent.DID_LOAD_SOURCE.value, Callback.wrap { bundle: Bundle? -> didLoadWasCalled = true })
+        container.on(InternalEvent.DID_NOT_LOAD_SOURCE.value, Callback.wrap { bundle: Bundle? -> didNotLoadWasCalled = true })
 
         container.load(source = "invalid_source.mp8")
         assertTrue("Will Load Source was not called", willLoadWasCalled)
+        assertTrue("Did Not Load Source was not called", didNotLoadWasCalled)
         assertFalse("Did Load Source was called", didLoadWasCalled)
     }
 }


### PR DESCRIPTION
This PR adds two events when loading a new source
- WILL_LOAD_SOURCE
- DID_LOAD_SOURCE
- DID_NOT_LOAD_SOURCE

This will be useful for plugins to know when a new source is set.