### PR TITLE
Feature/player load

### DIFF
--- a/clappr/src/main/kotlin/io/clappr/player/Player.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/Player.kt
@@ -176,7 +176,12 @@ open class Player(private val base: BaseObject = BaseObject()) : Fragment(), Eve
      *
      */
     open fun configure(options: Options) {
-        core = Core(loader, options)
+        core?.let {
+            it.options = options
+            it.activeContainer?.options = options
+        }.run {
+            core = Core(loader, options)
+        }
         core?.load()
     }
 

--- a/clappr/src/main/kotlin/io/clappr/player/Player.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/Player.kt
@@ -179,8 +179,7 @@ open class Player(private val base: BaseObject = BaseObject()) : Fragment(), Eve
         core?.let {
             it.options = options
         } ?: createCore(options)
-
-        core?.load()
+        load()
     }
 
     private fun createCore(options: Options){
@@ -210,6 +209,10 @@ open class Player(private val base: BaseObject = BaseObject()) : Fragment(), Eve
 
     fun load(source: String): Boolean {
         return load(source, null)
+    }
+
+    fun load(){
+        core?.load()
     }
 
     /**

--- a/clappr/src/main/kotlin/io/clappr/player/Player.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/Player.kt
@@ -178,7 +178,6 @@ open class Player(private val base: BaseObject = BaseObject()) : Fragment(), Eve
     open fun configure(options: Options) {
         core?.let {
             it.options = options
-            it.activeContainer?.options = options
         }.run {
             core = Core(loader, options)
         }

--- a/clappr/src/main/kotlin/io/clappr/player/Player.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/Player.kt
@@ -178,10 +178,13 @@ open class Player(private val base: BaseObject = BaseObject()) : Fragment(), Eve
     open fun configure(options: Options) {
         core?.let {
             it.options = options
-        }.run {
-            core = Core(loader, options)
-        }
+        } ?: createCore(options)
+
         core?.load()
+    }
+
+    private fun createCore(options: Options){
+        core = Core(loader, options)
     }
 
     /**

--- a/clappr/src/main/kotlin/io/clappr/player/base/InternalEvents.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/base/InternalEvents.kt
@@ -17,5 +17,6 @@ enum class InternalEvent (val value: String) {
     WILL_DESTROY("willDestroy"),
     DID_DESTROY("didDestroy"),
     MEDIA_OPTIONS_READY("mediaOptionsReady"),
-    MEDIA_OPTIONS_UPDATE("mediaOptionsUpdate")
+    MEDIA_OPTIONS_UPDATE("mediaOptionsUpdate"),
+    UPDATE_OPTIONS("updateOptions")
 }

--- a/clappr/src/main/kotlin/io/clappr/player/base/InternalEvents.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/base/InternalEvents.kt
@@ -18,5 +18,5 @@ enum class InternalEvent (val value: String) {
     DID_DESTROY("didDestroy"),
     MEDIA_OPTIONS_READY("mediaOptionsReady"),
     MEDIA_OPTIONS_UPDATE("mediaOptionsUpdate"),
-    UPDATE_OPTIONS("updateOptions")
+    DID_UPDATE_OPTIONS("didUpdateOptions")
 }

--- a/clappr/src/main/kotlin/io/clappr/player/components/Container.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/components/Container.kt
@@ -32,7 +32,6 @@ class Container(val loader: Loader, options: Options) : UIObject() {
     var options : Options = options
         set(options)  {
             field = options
-            playback = null
             trigger(InternalEvent.DID_UPDATE_OPTIONS.value)
         }
 

--- a/clappr/src/main/kotlin/io/clappr/player/components/Container.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/components/Container.kt
@@ -9,7 +9,7 @@ import io.clappr.player.plugin.Loader
 import io.clappr.player.plugin.Plugin
 import io.clappr.player.plugin.container.UIContainerPlugin
 
-class Container(val loader: Loader, var options: Options) : UIObject() {
+class Container(val loader: Loader, options: Options) : UIObject() {
     val plugins: List<Plugin>
         get() = internalPlugins
 
@@ -28,6 +28,12 @@ class Container(val loader: Loader, var options: Options) : UIObject() {
 
     val frameLayout: FrameLayout
         get() = view as FrameLayout
+
+    var options : Options = options
+        set(options)  {
+            field = options
+            playback?.options = options
+        }
 
     override val viewClass: Class<*>
         get() = FrameLayout::class.java

--- a/clappr/src/main/kotlin/io/clappr/player/components/Container.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/components/Container.kt
@@ -55,16 +55,12 @@ class Container(val loader: Loader, options: Options) : UIObject() {
     fun load(source: String, mimeType: String? = null): Boolean {
         trigger(InternalEvent.WILL_LOAD_SOURCE.value)
 
-        var supported = playback?.load(source, mimeType) ?: false
-
-        if (!supported) {
-            playback = loader.loadPlayback(source, mimeType, options)
-            if (playback?.name == NoOpPlayback.name) {
-                playback = null
-            }
-            supported = playback != null
-            render()
+        playback = loader.loadPlayback(source, mimeType, options)
+        if (playback?.name == NoOpPlayback.name) {
+            playback = null
         }
+        var supported = playback != null
+        render()
 
         val eventToTrigger = if (supported) InternalEvent.DID_LOAD_SOURCE else InternalEvent.DID_NOT_LOAD_SOURCE
         trigger(eventToTrigger.value)

--- a/clappr/src/main/kotlin/io/clappr/player/components/Container.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/components/Container.kt
@@ -33,6 +33,7 @@ class Container(val loader: Loader, options: Options) : UIObject() {
         set(options)  {
             field = options
             playback = null
+            trigger(InternalEvent.UPDATE_OPTIONS.value)
         }
 
     override val viewClass: Class<*>

--- a/clappr/src/main/kotlin/io/clappr/player/components/Container.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/components/Container.kt
@@ -9,7 +9,7 @@ import io.clappr.player.plugin.Loader
 import io.clappr.player.plugin.Plugin
 import io.clappr.player.plugin.container.UIContainerPlugin
 
-class Container(val loader: Loader, val options: Options) : UIObject() {
+class Container(val loader: Loader, var options: Options) : UIObject() {
     val plugins: List<Plugin>
         get() = internalPlugins
 

--- a/clappr/src/main/kotlin/io/clappr/player/components/Container.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/components/Container.kt
@@ -32,7 +32,7 @@ class Container(val loader: Loader, options: Options) : UIObject() {
     var options : Options = options
         set(options)  {
             field = options
-            playback?.options = options
+            playback = null
         }
 
     override val viewClass: Class<*>

--- a/clappr/src/main/kotlin/io/clappr/player/components/Container.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/components/Container.kt
@@ -33,7 +33,7 @@ class Container(val loader: Loader, options: Options) : UIObject() {
         set(options)  {
             field = options
             playback = null
-            trigger(InternalEvent.UPDATE_OPTIONS.value)
+            trigger(InternalEvent.DID_UPDATE_OPTIONS.value)
         }
 
     override val viewClass: Class<*>

--- a/clappr/src/main/kotlin/io/clappr/player/components/Core.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/components/Core.kt
@@ -65,9 +65,13 @@ class Core(val loader: Loader, options: Options) : UIObject() {
     var options : Options = options
         set(options)  {
             field = options
-            activeContainer?.options = options
+            updateContainerOptions(options)
+            trigger(InternalEvent.UPDATE_OPTIONS.value)
         }
 
+    private fun updateContainerOptions(options: Options) {
+        containers.forEach { it.options = options}
+    }
 
     override val viewClass: Class<*>
         get() = FrameLayout::class.java

--- a/clappr/src/main/kotlin/io/clappr/player/components/Core.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/components/Core.kt
@@ -65,8 +65,8 @@ class Core(val loader: Loader, options: Options) : UIObject() {
     var options : Options = options
         set(options)  {
             field = options
+            trigger(InternalEvent.DID_UPDATE_OPTIONS.value)
             updateContainerOptions(options)
-            trigger(InternalEvent.UPDATE_OPTIONS.value)
         }
 
     private fun updateContainerOptions(options: Options) {

--- a/clappr/src/main/kotlin/io/clappr/player/components/Core.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/components/Core.kt
@@ -10,7 +10,7 @@ import io.clappr.player.base.UIObject
 import io.clappr.player.plugin.Plugin
 import io.clappr.player.plugin.core.UICorePlugin
 
-class Core(val loader: Loader, val options: Options) : UIObject() {
+class Core(val loader: Loader, var options: Options) : UIObject() {
 
     enum class FullscreenState {
         EMBEDDED, FULLSCREEN

--- a/clappr/src/main/kotlin/io/clappr/player/components/Core.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/components/Core.kt
@@ -10,7 +10,7 @@ import io.clappr.player.base.UIObject
 import io.clappr.player.plugin.Plugin
 import io.clappr.player.plugin.core.UICorePlugin
 
-class Core(val loader: Loader, var options: Options) : UIObject() {
+class Core(val loader: Loader, options: Options) : UIObject() {
 
     enum class FullscreenState {
         EMBEDDED, FULLSCREEN
@@ -61,6 +61,13 @@ class Core(val loader: Loader, var options: Options) : UIObject() {
 
     val frameLayout: FrameLayout
         get() = view as FrameLayout
+
+    var options : Options = options
+        set(options)  {
+            field = options
+            activeContainer?.options = options
+        }
+
 
     override val viewClass: Class<*>
         get() = FrameLayout::class.java

--- a/clappr/src/main/kotlin/io/clappr/player/components/Playback.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/components/Playback.kt
@@ -14,7 +14,7 @@ interface PlaybackSupportInterface : NamedType {
     fun supportsSource(source: String, mimeType: String? = null): Boolean
 }
 
-abstract class Playback(var source: String, var mimeType: String? = null, var options: Options = Options()) : UIObject(), NamedType {
+abstract class Playback(var source: String, var mimeType: String? = null, val options: Options = Options()) : UIObject(), NamedType {
 
     enum class MediaType {
         UNKNOWN,

--- a/clappr/src/main/kotlin/io/clappr/player/components/Playback.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/components/Playback.kt
@@ -14,7 +14,7 @@ interface PlaybackSupportInterface : NamedType {
     fun supportsSource(source: String, mimeType: String? = null): Boolean
 }
 
-abstract class Playback(var source: String, var mimeType: String? = null, val options: Options = Options()) : UIObject(), NamedType {
+abstract class Playback(var source: String, var mimeType: String? = null, var options: Options = Options()) : UIObject(), NamedType {
 
     enum class MediaType {
         UNKNOWN,

--- a/clappr/src/main/kotlin/io/clappr/player/components/Playback.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/components/Playback.kt
@@ -48,7 +48,7 @@ abstract class Playback(var source: String, var mimeType: String? = null, option
     var options : Options = options
         set(options)  {
             field = options
-            trigger(InternalEvent.UPDATE_OPTIONS.value)
+            trigger(InternalEvent.DID_UPDATE_OPTIONS.value)
         }
 
     open val mediaType: MediaType

--- a/clappr/src/main/kotlin/io/clappr/player/components/Playback.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/components/Playback.kt
@@ -14,7 +14,7 @@ interface PlaybackSupportInterface : NamedType {
     fun supportsSource(source: String, mimeType: String? = null): Boolean
 }
 
-abstract class Playback(var source: String, var mimeType: String? = null, val options: Options = Options()) : UIObject(), NamedType {
+abstract class Playback(var source: String, var mimeType: String? = null, options: Options = Options()) : UIObject(), NamedType {
 
     enum class MediaType {
         UNKNOWN,
@@ -44,6 +44,12 @@ abstract class Playback(var source: String, var mimeType: String? = null, val op
     open fun destroy() {
         stopListening()
     }
+
+    var options : Options = options
+        set(options)  {
+            field = options
+            trigger(InternalEvent.UPDATE_OPTIONS.value)
+        }
 
     open val mediaType: MediaType
         get() = MediaType.UNKNOWN

--- a/clappr/src/main/kotlin/io/clappr/player/playback/ExoPlayerPlayBack.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/playback/ExoPlayerPlayBack.kt
@@ -35,6 +35,10 @@ open class ExoPlayerPlayback(source: String, mimeType: String? = null, options: 
         val tag: String = "ExoPlayerPlayback"
 
         override fun supportsSource(source: String, mimeType: String?): Boolean {
+            mimeType?.let {
+                if (it.startsWith("application/video-id")) return false
+            }
+
             val uri = Uri.parse(source)
             val type = Util.inferContentType(uri.lastPathSegment)
             return type == C.TYPE_SS || type == C.TYPE_HLS || type == C.TYPE_DASH || type == C.TYPE_OTHER
@@ -171,13 +175,16 @@ open class ExoPlayerPlayback(source: String, mimeType: String? = null, options: 
     }
 
     override fun load(source: String, mimeType: String?): Boolean {
-        trigger(Event.WILL_CHANGE_SOURCE)
-        this.source = source
-        this.mimeType = mimeType
-        stop()
-        setupPlayer()
-        trigger(Event.DID_CHANGE_SOURCE)
-        return true
+        val supported = super.load(source, mimeType)
+        if(supported){
+            trigger(Event.WILL_CHANGE_SOURCE)
+            this.source = source
+            this.mimeType = mimeType
+            stop()
+            setupPlayer()
+            trigger(Event.DID_CHANGE_SOURCE)
+        }
+        return supported
     }
 
     private fun mediaSource(uri: Uri): MediaSource {

--- a/clappr/src/main/kotlin/io/clappr/player/playback/ExoPlayerPlayBack.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/playback/ExoPlayerPlayBack.kt
@@ -35,10 +35,6 @@ open class ExoPlayerPlayback(source: String, mimeType: String? = null, options: 
         val tag: String = "ExoPlayerPlayback"
 
         override fun supportsSource(source: String, mimeType: String?): Boolean {
-            mimeType?.let {
-                if (it.startsWith("application/video-id")) return false
-            }
-
             val uri = Uri.parse(source)
             val type = Util.inferContentType(uri.lastPathSegment)
             return type == C.TYPE_SS || type == C.TYPE_HLS || type == C.TYPE_DASH || type == C.TYPE_OTHER
@@ -175,16 +171,12 @@ open class ExoPlayerPlayback(source: String, mimeType: String? = null, options: 
     }
 
     override fun load(source: String, mimeType: String?): Boolean {
-        val supported = super.load(source, mimeType)
-        if(supported){
-            trigger(Event.WILL_CHANGE_SOURCE)
-            this.source = source
-            this.mimeType = mimeType
-            stop()
-            setupPlayer()
-            trigger(Event.DID_CHANGE_SOURCE)
-        }
-        return supported
+        trigger(Event.WILL_CHANGE_SOURCE)
+        this.source = source
+        this.mimeType = mimeType
+        stop()
+        setupPlayer()
+        trigger(Event.DID_CHANGE_SOURCE)
     }
 
     private fun mediaSource(uri: Uri): MediaSource {

--- a/clappr/src/main/kotlin/io/clappr/player/playback/ExoPlayerPlayBack.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/playback/ExoPlayerPlayBack.kt
@@ -177,6 +177,7 @@ open class ExoPlayerPlayback(source: String, mimeType: String? = null, options: 
         stop()
         setupPlayer()
         trigger(Event.DID_CHANGE_SOURCE)
+        return true
     }
 
     private fun mediaSource(uri: Uri): MediaSource {

--- a/clappr/src/main/kotlin/io/clappr/player/plugin/PosterPlugin.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/plugin/PosterPlugin.kt
@@ -22,7 +22,9 @@ class PosterPlugin(container: Container): UIContainerPlugin(container) {
 
     private val imageView = ImageView(context)
 
-    private var posterImageUrl: String? = null
+    var posterImageUrl: String? = null
+        get() = posterImageUrl
+        private set
 
     companion object : NamedType {
         override val name = "poster"
@@ -48,7 +50,7 @@ class PosterPlugin(container: Container): UIContainerPlugin(container) {
         get() = posterLayout
 
     init {
-        posterImageUrl = container.options[ClapprOption.POSTER.value] as? String
+        updateImageUrlFromOptions()
         setupPosterLayout()
         bindEventListeners()
     }
@@ -57,6 +59,7 @@ class PosterPlugin(container: Container): UIContainerPlugin(container) {
         updatePoster()
         listenTo(container, InternalEvent.DID_CHANGE_PLAYBACK.value, Callback.wrap { bindPlaybackListeners() })
         listenTo(container, Event.REQUEST_POSTER_UPDATE.value, Callback.wrap { it -> updatePoster(it) })
+        listenTo(container, InternalEvent.UPDATE_OPTIONS.value, Callback.wrap { updateImageUrlFromOptions() })
     }
 
     fun bindPlaybackListeners() {
@@ -67,6 +70,10 @@ class PosterPlugin(container: Container): UIContainerPlugin(container) {
             listenTo(it, Event.DID_STOP.value, Callback.wrap { show() })
             listenTo(it, Event.DID_COMPLETE.value, Callback.wrap { show() })
         }
+    }
+
+    private fun updateImageUrlFromOptions(){
+        posterImageUrl = container.options[ClapprOption.POSTER.value] as? String
     }
 
     private fun setupPosterLayout() {

--- a/clappr/src/main/kotlin/io/clappr/player/plugin/PosterPlugin.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/plugin/PosterPlugin.kt
@@ -58,7 +58,7 @@ class PosterPlugin(container: Container): UIContainerPlugin(container) {
         updatePoster()
         listenTo(container, InternalEvent.DID_CHANGE_PLAYBACK.value, Callback.wrap { bindPlaybackListeners() })
         listenTo(container, Event.REQUEST_POSTER_UPDATE.value, Callback.wrap { it -> updatePoster(it) })
-        listenTo(container, InternalEvent.UPDATE_OPTIONS.value, Callback.wrap { updateImageUrlFromOptions() })
+        listenTo(container, InternalEvent.DID_UPDATE_OPTIONS.value, Callback.wrap { updateImageUrlFromOptions() })
     }
 
     fun bindPlaybackListeners() {

--- a/clappr/src/main/kotlin/io/clappr/player/plugin/PosterPlugin.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/plugin/PosterPlugin.kt
@@ -23,7 +23,6 @@ class PosterPlugin(container: Container): UIContainerPlugin(container) {
     private val imageView = ImageView(context)
 
     var posterImageUrl: String? = null
-        get() = posterImageUrl
         private set
 
     companion object : NamedType {

--- a/clappr/src/test/kotlin/io/clappr/player/PlayerTest.kt
+++ b/clappr/src/test/kotlin/io/clappr/player/PlayerTest.kt
@@ -168,4 +168,30 @@ open class PlayerTest {
         assertTrue("Did destroy not triggered", didDestroyTriggered)
     }
 
+    @Test
+    fun shouldCoreHaveSameInstanceOnPlayerConfigure() {
+        player.configure(Options(source = "valid"))
+        val expectedCore = player.core
+        player.configure(Options(source = ""))
+
+        assertSame(expectedCore, player.core)
+    }
+
+    @Test
+    fun shouldCoreChangeOptionsOnPlayerConfigure() {
+        player.configure(Options(source = "valid"))
+        val expectedSource = "new source"
+        player.configure(Options(expectedSource))
+
+        assertSame(expectedSource, player.core?.options?.source)
+    }
+
+    @Test
+    fun shouldCoreChangeOptionsOnPlayerLoad() {
+        player.configure(Options(source = "valid"))
+        val expectedSource = "new source"
+        player.load(expectedSource)
+
+        assertSame(expectedSource, player.core?.options?.source)
+    }
 }

--- a/clappr/src/test/kotlin/io/clappr/player/PlayerTest.kt
+++ b/clappr/src/test/kotlin/io/clappr/player/PlayerTest.kt
@@ -157,18 +157,6 @@ open class PlayerTest {
     }
 
     @Test
-    fun shouldDestroyCorePluginsOnConfigure() {
-        player.configure(Options(source = "valid"))
-
-        var didDestroyTriggered = false
-        player.listenTo(player.core!!, InternalEvent.DID_DESTROY.value, Callback.wrap { didDestroyTriggered = true })
-
-        player.configure(Options(source = ""))
-
-        assertTrue("Did destroy not triggered", didDestroyTriggered)
-    }
-
-    @Test
     fun shouldCoreHaveSameInstanceOnPlayerConfigure() {
         player.configure(Options(source = "valid"))
         val expectedCore = player.core

--- a/clappr/src/test/kotlin/io/clappr/player/components/ContainerTest.kt
+++ b/clappr/src/test/kotlin/io/clappr/player/components/ContainerTest.kt
@@ -249,4 +249,13 @@ open class ContainerTest {
         triggerObject.trigger("containerTest")
         assertEquals("trigger", 1, numberOfTriggers)
     }
+
+    @Test
+    fun shouldSetActivePlaybackNullWhenSetOptions() {
+        val container = Container(Loader(), Options())
+        container.playback = MP4Playback("source.mp4", "mimetype", Options())
+        container.options = Options()
+
+        assertNull(container.playback)
+    }
 }

--- a/clappr/src/test/kotlin/io/clappr/player/components/ContainerTest.kt
+++ b/clappr/src/test/kotlin/io/clappr/player/components/ContainerTest.kt
@@ -275,10 +275,10 @@ open class ContainerTest {
         val container = Container(Loader(), options = Options()).apply { load(source) }
 
         var callbackWasCalled = false
-        container.on(InternalEvent.UPDATE_OPTIONS.value, Callback.wrap { callbackWasCalled = true })
+        container.on(InternalEvent.DID_UPDATE_OPTIONS.value, Callback.wrap { callbackWasCalled = true })
 
         container.options = Options(source = "new_source")
 
-        assertTrue("should trigger UPDATE_OPTIONS on set options", callbackWasCalled)
+        assertTrue("should trigger DID_UPDATE_OPTIONS on set options", callbackWasCalled)
     }
 }

--- a/clappr/src/test/kotlin/io/clappr/player/components/ContainerTest.kt
+++ b/clappr/src/test/kotlin/io/clappr/player/components/ContainerTest.kt
@@ -267,4 +267,18 @@ open class ContainerTest {
 
         assertEquals(container.options, container.playback?.options)
     }
+
+    @Test
+    fun shouldTriggerUpdateOptionOnSetOptions() {
+        Loader.registerPlayback(MP4Playback::class)
+        val source = "some_source.mp4"
+        val container = Container(Loader(), options = Options()).apply { load(source) }
+
+        var callbackWasCalled = false
+        container.on(InternalEvent.UPDATE_OPTIONS.value, Callback.wrap { callbackWasCalled = true })
+
+        container.options = Options(source = "new_source")
+
+        assertTrue("should trigger UPDATE_OPTIONS on set options", callbackWasCalled)
+    }
 }

--- a/clappr/src/test/kotlin/io/clappr/player/components/ContainerTest.kt
+++ b/clappr/src/test/kotlin/io/clappr/player/components/ContainerTest.kt
@@ -97,20 +97,6 @@ open class ContainerTest {
     }
 
     @Test
-    fun shouldNotTriggerPlaybackChangedWhenSamePlayback() {
-        Loader.registerPlayback(MP4Playback::class)
-        val container = Container(Loader(), Options())
-        container.load("some_unknown_source.mp4")
-
-        var callbackWasCalled = false
-        container.on(InternalEvent.WILL_CHANGE_PLAYBACK.value, Callback.wrap { callbackWasCalled = true})
-        container.on(InternalEvent.DID_CHANGE_PLAYBACK.value, Callback.wrap { callbackWasCalled = true })
-
-        container.load(source = "some_unknown_source.mp4")
-        assertFalse("CHANGE_PLAYBACK triggered", callbackWasCalled)
-    }
-
-    @Test
     fun shouldTriggerLoadSourceEventsOnNewSource() {
         Loader.registerPlayback(MP4Playback::class)
         val container = Container(Loader(), Options("aSource.mp4"))
@@ -248,15 +234,6 @@ open class ContainerTest {
 
         triggerObject.trigger("containerTest")
         assertEquals("trigger", 1, numberOfTriggers)
-    }
-
-    @Test
-    fun shouldSetActivePlaybackNullWhenSetOptions() {
-        val container = Container(Loader(), Options())
-        container.playback = MP4Playback("source.mp4", "mimetype", Options())
-        container.options = Options()
-
-        assertNull(container.playback)
     }
 
     @Test

--- a/clappr/src/test/kotlin/io/clappr/player/components/ContainerTest.kt
+++ b/clappr/src/test/kotlin/io/clappr/player/components/ContainerTest.kt
@@ -240,8 +240,12 @@ open class ContainerTest {
     fun shouldSetPlaybackOptionsWhenLoadContainer() {
         Loader.registerPlayback(MP4Playback::class)
         val source = "some_source.mp4"
-        val container = Container(Loader(), options = Options()).apply { load(source) }
+        val newOptions = Options()
+        newOptions.put(ClapprOption.POSTER.value, "fake-poster-url")
 
+        val container = Container(Loader(), options = newOptions).apply { load(source) }
+
+        assertNotNull(container.options)
         assertEquals(container.options, container.playback?.options)
     }
 

--- a/clappr/src/test/kotlin/io/clappr/player/components/ContainerTest.kt
+++ b/clappr/src/test/kotlin/io/clappr/player/components/ContainerTest.kt
@@ -258,4 +258,13 @@ open class ContainerTest {
 
         assertNull(container.playback)
     }
+
+    @Test
+    fun shouldSetPlaybackOptionsWhenLoadContainer() {
+        Loader.registerPlayback(MP4Playback::class)
+        val source = "some_source.mp4"
+        val container = Container(Loader(), options = Options()).apply { load(source) }
+
+        assertEquals(container.options, container.playback?.options)
+    }
 }

--- a/clappr/src/test/kotlin/io/clappr/player/components/CoreTest.kt
+++ b/clappr/src/test/kotlin/io/clappr/player/components/CoreTest.kt
@@ -1,5 +1,4 @@
 package io.clappr.player.base
-import android.os.Bundle
 import io.clappr.player.BuildConfig
 import io.clappr.player.components.Container
 import io.clappr.player.components.Core
@@ -220,10 +219,10 @@ open class CoreTest {
         val core = Core(Loader(), options = Options(source = "some_source")).apply { load() }
 
         var callbackWasCalled = false
-        core.on(InternalEvent.UPDATE_OPTIONS.value, Callback.wrap { callbackWasCalled = true })
+        core.on(InternalEvent.DID_UPDATE_OPTIONS.value, Callback.wrap { callbackWasCalled = true })
 
         core.options = Options(source = "new_source")
 
-        assertTrue("should trigger UPDATE_OPTIONS on set options", callbackWasCalled)
+        assertTrue("should trigger DID_UPDATE_OPTIONS on set options", callbackWasCalled)
     }
 }

--- a/clappr/src/test/kotlin/io/clappr/player/components/CoreTest.kt
+++ b/clappr/src/test/kotlin/io/clappr/player/components/CoreTest.kt
@@ -206,4 +206,12 @@ open class CoreTest {
         triggerObject.trigger("coreTest")
         assertEquals("trigger", 1, numberOfTriggers)
     }
+
+    @Test
+    fun shouldSetContainerOptionsWhenSetOptions() {
+        val core = Core(Loader(), options = Options(source = "some_source")).apply { load() }
+        core.options = Options(source = "newsource")
+
+        assertEquals(core.options, core.activeContainer?.options)
+    }
 }

--- a/clappr/src/test/kotlin/io/clappr/player/components/CoreTest.kt
+++ b/clappr/src/test/kotlin/io/clappr/player/components/CoreTest.kt
@@ -210,8 +210,20 @@ open class CoreTest {
     @Test
     fun shouldSetContainerOptionsWhenSetOptions() {
         val core = Core(Loader(), options = Options(source = "some_source")).apply { load() }
-        core.options = Options(source = "newsource")
+        core.options = Options(source = "new_source")
 
         assertEquals(core.options, core.activeContainer?.options)
+    }
+
+    @Test
+    fun shouldTriggerUpdateOptionOnSetOptions() {
+        val core = Core(Loader(), options = Options(source = "some_source")).apply { load() }
+
+        var callbackWasCalled = false
+        core.on(InternalEvent.UPDATE_OPTIONS.value, Callback.wrap { callbackWasCalled = true })
+
+        core.options = Options(source = "new_source")
+
+        assertTrue("should trigger UPDATE_OPTIONS on set options", callbackWasCalled)
     }
 }

--- a/clappr/src/test/kotlin/io/clappr/player/components/PlaybackTest.kt
+++ b/clappr/src/test/kotlin/io/clappr/player/components/PlaybackTest.kt
@@ -303,4 +303,16 @@ open class PlaybackTest {
             fail("Exception: ${ex.message}")
         }
     }
+
+    @Test
+    fun shouldTriggerUpdateOptionOnSetOptions() {
+        val playback = SomePlayback("valid-source.mp4", Options())
+
+        var callbackWasCalled = false
+        playback.on(InternalEvent.UPDATE_OPTIONS.value, Callback.wrap { callbackWasCalled = true })
+
+        playback.options = Options(source = "new_source")
+
+        assertTrue("should trigger UPDATE_OPTIONS on set options", callbackWasCalled)
+    }
 }

--- a/clappr/src/test/kotlin/io/clappr/player/components/PlaybackTest.kt
+++ b/clappr/src/test/kotlin/io/clappr/player/components/PlaybackTest.kt
@@ -309,10 +309,10 @@ open class PlaybackTest {
         val playback = SomePlayback("valid-source.mp4", Options())
 
         var callbackWasCalled = false
-        playback.on(InternalEvent.UPDATE_OPTIONS.value, Callback.wrap { callbackWasCalled = true })
+        playback.on(InternalEvent.DID_UPDATE_OPTIONS.value, Callback.wrap { callbackWasCalled = true })
 
         playback.options = Options(source = "new_source")
 
-        assertTrue("should trigger UPDATE_OPTIONS on set options", callbackWasCalled)
+        assertTrue("should trigger DID_UPDATE_OPTIONS on set options", callbackWasCalled)
     }
 }

--- a/clappr/src/test/kotlin/io/clappr/player/plugin/PosterPluginTest.kt
+++ b/clappr/src/test/kotlin/io/clappr/player/plugin/PosterPluginTest.kt
@@ -1,0 +1,45 @@
+package io.clappr.player.plugin
+
+import io.clappr.player.BuildConfig
+import io.clappr.player.Player
+import io.clappr.player.base.*
+import io.clappr.player.components.Container
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+import org.junit.Assert.*
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.robolectric.shadows.ShadowApplication
+
+@RunWith(RobolectricTestRunner::class)
+@Config(constants = BuildConfig::class, sdk = intArrayOf(23))
+class PosterPluginTest {
+
+    @Before
+    fun setUp() {
+        Player.initialize(ShadowApplication.getInstance().applicationContext)
+
+        Loader.registerPlugin(PosterPlugin::class)
+    }
+
+    @After
+    fun tearDown() {
+        Loader.clearPlugins()
+    }
+
+    @Test
+    fun shouldUpdateImageUrlWhenUpdateOptionsIsTriggered() {
+        val container = Container(Loader(), Options())
+        val posterPlugin = container.plugins.filterIsInstance(PosterPlugin::class.java).first()
+        val expectedImageUrl = "image_url"
+
+        val option = Options()
+        option.put(ClapprOption.POSTER.value, expectedImageUrl)
+        container.options = option
+
+        assertEquals(expectedImageUrl, posterPlugin.posterImageUrl)
+    }
+}


### PR DESCRIPTION
# Goals

Player must be able to load/configure a video without restarting
- Load: change video without destroying the Player
- Configure: (1) Change options; (2) Load if new source; (3) without destroying the Player
- And ensure plugins that read the options are notified. Core, Container, and Playback will trigger a UPDATE_OPTIONS internal event.

# How to test
- Load different videos with different options
