### PR TITLE
Feature: Periodic DVR state  update 

### DIFF
--- a/clappr/src/main/kotlin/io/clappr/player/playback/ExoPlayerPlayBack.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/playback/ExoPlayerPlayBack.kt
@@ -101,7 +101,7 @@ open class ExoPlayerPlayback(source: String, mimeType: String? = null, options: 
             return MediaType.UNKNOWN
         }
 
-    private val syncBufferInSeconds = if (mediaType == MediaType.LIVE) DEFAULT_SYNC_BUFFER_IN_SECONDS else 0
+    private val syncBufferInSeconds = if (mediaType == MediaType.LIVE) DEFAULT_SYNC_BUFFER_IN_SECONDS + MIN_TIME_TO_CONSIDER_IN_DVR_USE_IN_SECONDS else 0
 
     override val duration: Double
         get() = player?.duration?.let { (it.toDouble() / ONE_SECOND_IN_MILLIS) - syncBufferInSeconds } ?: Double.NaN
@@ -338,7 +338,7 @@ open class ExoPlayerPlayback(source: String, mimeType: String? = null, options: 
 
     private fun updateIsDvrInUse() {
         val forcedDvrValue = state != State.PLAYING
-        val isInDvr = position < (duration - MIN_TIME_TO_CONSIDER_IN_DVR_USE_IN_SECONDS)
+        val isInDvr = position < duration
         exoplayerIsDvrInUse = isDvrAvailable && (forcedDvrValue || isInDvr)
     }
 

--- a/clappr/src/main/kotlin/io/clappr/player/playback/ExoPlayerPlayBack.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/playback/ExoPlayerPlayBack.kt
@@ -44,7 +44,7 @@ open class ExoPlayerPlayback(source: String, mimeType: String? = null, options: 
 
     private val ONE_SECOND_IN_MILLIS: Int = 1000
     private val DEFAULT_MIN_DVR_SIZE = 60
-    private val MIN_TIME_TO_CONSIDER_IN_DVR_USE_IN_SECONDS = DefaultLoadControl.DEFAULT_BUFFER_FOR_PLAYBACK_MS / ONE_SECOND_IN_MILLIS
+    private val MIN_TIME_TO_CONSIDER_IN_DVR_USE_IN_SECONDS = 5
     private val DEFAULT_SYNC_BUFFER_IN_SECONDS = DefaultLoadControl.DEFAULT_MIN_BUFFER_MS / ONE_SECOND_IN_MILLIS
 
     open val minDvrSize by lazy { options[ClapprOption.MIN_DVR_SIZE.value] as? Int ?: DEFAULT_MIN_DVR_SIZE }

--- a/clappr/src/main/kotlin/io/clappr/player/playback/ExoPlayerPlayBack.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/playback/ExoPlayerPlayBack.kt
@@ -44,8 +44,8 @@ open class ExoPlayerPlayback(source: String, mimeType: String? = null, options: 
 
     private val ONE_SECOND_IN_MILLIS: Int = 1000
     private val DEFAULT_MIN_DVR_SIZE = 60
-    private val MIN_TIME_TO_CONSIDER_IN_DVR_USE_IN_SECONDS = 20
-    private val DEFAULT_SYNC_BUFFER_IN_SECONDS = 30
+    private val MIN_TIME_TO_CONSIDER_IN_DVR_USE_IN_SECONDS = DefaultLoadControl.DEFAULT_BUFFER_FOR_PLAYBACK_MS / ONE_SECOND_IN_MILLIS
+    private val DEFAULT_SYNC_BUFFER_IN_SECONDS = DefaultLoadControl.DEFAULT_MIN_BUFFER_MS / ONE_SECOND_IN_MILLIS
 
     open val minDvrSize by lazy { options[ClapprOption.MIN_DVR_SIZE.value] as? Int ?: DEFAULT_MIN_DVR_SIZE }
 

--- a/clappr/src/main/kotlin/io/clappr/player/playback/ExoPlayerPlayBack.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/playback/ExoPlayerPlayBack.kt
@@ -98,11 +98,13 @@ open class ExoPlayerPlayback(source: String, mimeType: String? = null, options: 
             return MediaType.UNKNOWN
         }
 
+    private val syncBufferInSeconds = if (mediaType == MediaType.VOD) 0 else 30
+
     override val duration: Double
-        get() = player?.duration?.let { it.toDouble() / ONE_SECOND_IN_MILLIS } ?: Double.NaN
+        get() = player?.duration?.let { (it.toDouble() / ONE_SECOND_IN_MILLIS) - syncBufferInSeconds } ?: Double.NaN
 
     override val position: Double
-        get() = player?.currentPosition?.let { it.toDouble() / ONE_SECOND_IN_MILLIS } ?: Double.NaN
+        get() = player?.currentPosition?.let { (it.toDouble() / ONE_SECOND_IN_MILLIS) - syncBufferInSeconds } ?: Double.NaN
 
     override val state: State
         get() = currentState
@@ -138,7 +140,7 @@ open class ExoPlayerPlayback(source: String, mimeType: String? = null, options: 
         }
 
     override val isDvrInUse: Boolean
-        get() = isDvrAvailable && position <= duration - minDvrSize
+        get() = isDvrAvailable && position < duration
 
     private var lastDrvAvailableCheck: Boolean? = null
     private var lastDvrInUseCheck: Boolean? = null

--- a/clappr/src/main/kotlin/io/clappr/player/playback/ExoPlayerPlayBack.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/playback/ExoPlayerPlayBack.kt
@@ -287,10 +287,11 @@ open class ExoPlayerPlayback(source: String, mimeType: String? = null, options: 
     }
 
     private fun checkPeriodicUpdates() {
-        if (bufferPercentage != lastBufferPercentageSent) triggerBufferUpdateEvent()
-        if (position != lastPositionSent) triggerPositionUpdateEvent()
         updateDvrAvailableState()
         updateIsDvrInUseState()
+
+        if (bufferPercentage != lastBufferPercentageSent) triggerBufferUpdateEvent()
+        if (position != lastPositionSent) triggerPositionUpdateEvent()
     }
 
     private fun triggerBufferUpdateEvent() {

--- a/clappr/src/main/kotlin/io/clappr/player/playback/ExoPlayerPlayBack.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/playback/ExoPlayerPlayBack.kt
@@ -358,8 +358,6 @@ open class ExoPlayerPlayback(source: String, mimeType: String? = null, options: 
             currentState = State.PAUSED
             trigger(Event.DID_PAUSE)
         }
-
-        updateIsDvrInUseState()
     }
 
     private fun handleExoplayerBufferingState() {

--- a/clappr/src/main/kotlin/io/clappr/player/playback/ExoPlayerPlayBack.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/playback/ExoPlayerPlayBack.kt
@@ -44,7 +44,7 @@ open class ExoPlayerPlayback(source: String, mimeType: String? = null, options: 
 
     private val ONE_SECOND_IN_MILLIS: Int = 1000
     private val DEFAULT_MIN_DVR_SIZE = 60
-    private val MIN_TIME_TO_CONSIDER_IN_DVR_USE_IN_SECONDS = 5
+    private val MIN_DVR_LIVE_DRIFT = 5
     private val DEFAULT_SYNC_BUFFER_IN_SECONDS = DefaultLoadControl.DEFAULT_MIN_BUFFER_MS / ONE_SECOND_IN_MILLIS
 
     open val minDvrSize by lazy { options[ClapprOption.MIN_DVR_SIZE.value] as? Int ?: DEFAULT_MIN_DVR_SIZE }
@@ -101,7 +101,7 @@ open class ExoPlayerPlayback(source: String, mimeType: String? = null, options: 
             return MediaType.UNKNOWN
         }
 
-    private val syncBufferInSeconds = if (mediaType == MediaType.LIVE) DEFAULT_SYNC_BUFFER_IN_SECONDS + MIN_TIME_TO_CONSIDER_IN_DVR_USE_IN_SECONDS else 0
+    private val syncBufferInSeconds = if (mediaType == MediaType.LIVE) DEFAULT_SYNC_BUFFER_IN_SECONDS + MIN_DVR_LIVE_DRIFT else 0
 
     override val duration: Double
         get() = player?.duration?.let { (it.toDouble() / ONE_SECOND_IN_MILLIS) - syncBufferInSeconds } ?: Double.NaN

--- a/clappr/src/main/kotlin/io/clappr/player/playback/ExoPlayerPlayBack.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/playback/ExoPlayerPlayBack.kt
@@ -205,8 +205,6 @@ open class ExoPlayerPlayback(source: String, mimeType: String? = null, options: 
         trigger(Event.DID_SEEK)
         triggerPositionUpdateEvent()
 
-        updateIsDvrInUseState()
-
         return true
     }
 
@@ -287,6 +285,7 @@ open class ExoPlayerPlayback(source: String, mimeType: String? = null, options: 
         if (bufferPercentage != lastBufferPercentageSent) triggerBufferUpdateEvent()
         if (position != lastPositionSent) triggerPositionUpdateEvent()
         updateDvrAvailableState()
+        updateIsDvrInUseState()
     }
 
     private fun triggerBufferUpdateEvent() {

--- a/clappr/src/main/kotlin/io/clappr/player/playback/ExoPlayerPlayBack.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/playback/ExoPlayerPlayBack.kt
@@ -98,7 +98,7 @@ open class ExoPlayerPlayback(source: String, mimeType: String? = null, options: 
             return MediaType.UNKNOWN
         }
 
-    private val syncBufferInSeconds = if (mediaType == MediaType.VOD) 0 else 30
+    private val syncBufferInSeconds = if (mediaType == MediaType.LIVE) 30 else 0
 
     override val duration: Double
         get() = player?.duration?.let { (it.toDouble() / ONE_SECOND_IN_MILLIS) - syncBufferInSeconds } ?: Double.NaN
@@ -140,7 +140,7 @@ open class ExoPlayerPlayback(source: String, mimeType: String? = null, options: 
         }
 
     override val isDvrInUse: Boolean
-        get() = isDvrAvailable && position < duration
+        get() = isDvrAvailable && position < (duration - 20)
 
     private var lastDrvAvailableCheck: Boolean? = null
     private var lastDvrInUseCheck: Boolean? = null

--- a/clappr/src/main/kotlin/io/clappr/player/playback/ExoPlayerPlayBack.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/playback/ExoPlayerPlayBack.kt
@@ -6,7 +6,9 @@ import android.net.Uri
 import android.os.Bundle
 import android.os.Handler
 import android.view.View
+import com.google.android.exoplayer2.*
 import com.google.android.exoplayer2.drm.*
+import com.google.android.exoplayer2.source.*
 import com.google.android.exoplayer2.source.dash.DashMediaSource
 import com.google.android.exoplayer2.source.dash.DefaultDashChunkSource
 import com.google.android.exoplayer2.source.hls.HlsMediaSource


### PR DESCRIPTION
Identify when the player start in DVR state while it is on pause.

# How to Test
1 - Load live video with DVR
2 - Pause video
3 - After few seconds check that the `DID_CHANGE_DVR_STATUS` was trigged.