### PR TITLE
Fix playing live videos when in background

### DIFF
--- a/clappr/src/main/kotlin/io/clappr/player/Player.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/Player.kt
@@ -154,9 +154,8 @@ open class Player(private val base: BaseObject = BaseObject()) : Fragment(), Eve
 
     override fun onPause() {
         super.onPause()
-        activity?.let {
-            if (!it.isRunningInAndroidTvDevice())
-                pause()
+        activity?.takeUnless { it.isRunningInAndroidTvDevice()}?.let {
+            if(!pause()) stop()
         }
     }
 

--- a/clappr/src/main/kotlin/io/clappr/player/Player.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/Player.kt
@@ -154,8 +154,8 @@ open class Player(private val base: BaseObject = BaseObject()) : Fragment(), Eve
 
     override fun onPause() {
         super.onPause()
-        activity?.takeUnless { it.isRunningInAndroidTvDevice()}?.let {
-            if(!pause()) stop()
+        activity?.takeUnless { it.isRunningInAndroidTvDevice() }?.let {
+            if (!pause()) stop()
         }
     }
 


### PR DESCRIPTION
Fixes problem when a video live is not pausing when `onResume()` fragment method is called.

#How to test
1 - Play a live vide then click home buttom
2 - When return to activity the video should be stoped.