### PR TITLE
Fix/live time info

### DIFF
--- a/clappr/src/main/kotlin/io/clappr/player/playback/ExoPlayerPlayBack.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/playback/ExoPlayerPlayBack.kt
@@ -166,7 +166,7 @@ open class ExoPlayerPlayback(source: String, mimeType: String? = null, options: 
         get() = dvrStartTimeinSeconds
 
     override val currentTime: Long?
-        get() = currentDate?.plus(duration.toLong())
+        get() = currentDate?.plus(position.toLong())
 
     init {
         playerView.useController = false


### PR DESCRIPTION
Make `currentTime` return Live `video start time` + `current video position`.