### PR TITLE
fix(player_on_pause): only try to pause player when it is not paused …

### DIFF
--- a/clappr/src/main/kotlin/io/clappr/player/Player.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/Player.kt
@@ -155,7 +155,9 @@ open class Player(private val base: BaseObject = BaseObject()) : Fragment(), Eve
     override fun onPause() {
         super.onPause()
         activity?.takeUnless { it.isRunningInAndroidTvDevice() }?.let {
-            if (!pause()) stop()
+            val playerIsNotPaused = core?.activePlayback?.state != Playback.State.PAUSED
+            if (playerIsNotPaused && !pause())
+                stop()
         }
     }
 


### PR DESCRIPTION
Fix bug when call `stop()`on `onPause()` when player is paused.