### PR TITLE
Improve Play Button Listeners Handling

### DIFF
--- a/clappr/src/main/kotlin/io/clappr/player/plugin/control/PlayButton.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/plugin/control/PlayButton.kt
@@ -53,7 +53,7 @@ open class PlayButton(core: Core) : ButtonPlugin(core) {
         }
     }
 
-    fun stopPlaybackListeners() {
+    private fun stopPlaybackListeners() {
         playbackListenerIds.forEach(::stopListening)
         playbackListenerIds.clear()
     }

--- a/clappr/src/test/kotlin/io/clappr/player/plugin/control/PlayButtonTest.kt
+++ b/clappr/src/test/kotlin/io/clappr/player/plugin/control/PlayButtonTest.kt
@@ -34,11 +34,46 @@ class PlayButtonTest {
 
         container = Container(Loader(), Options())
         core = Core(Loader(), Options())
-        container.playback = FakePlayback()
 
         playButton = PlayButton(core)
 
         core.activeContainer = container
+        container.playback = FakePlayback()
+    }
+
+    @Test
+    fun shouldNotHavePlaybackListenersWhenInit() {
+        playButton = PlayButton(core)
+
+        assertTrue(playButton.playbackListenerIds.size == 0,
+                "Playback listeners should not be registered")
+    }
+
+    @Test
+    fun shouldBindPlaybackListenersWhenDidChangeActivePlaybackEventIsTriggered() {
+        playButton.playbackListenerIds.clear()
+
+        container.playback = FakePlayback()
+
+        assertTrue(playButton.playbackListenerIds.size > 0,
+                "Playback listeners should be registered")
+    }
+
+    @Test
+    fun shouldRemoveAllPlaybackListenersBeforeBindNewOnesWhenDidChangeActivePlaybackEventIsTriggered() {
+        val expectedAmountOfListener = 5
+
+        container.playback = FakePlayback()
+
+        assertEquals(expectedAmountOfListener, playButton.playbackListenerIds.size)
+    }
+
+    @Test
+    fun shouldRemoveAllPlaybackListenersWhenPluginIsDestroyed() {
+        playButton.destroy()
+
+        assertTrue(playButton.playbackListenerIds.size == 0,
+                "Playback listeners should not be registered")
     }
 
     @Test


### PR DESCRIPTION
### Goal
Improve Play Button listeners handling by stop listening Playback events when plugin is destroyed.

### How to Test
1 - Run Unit Tests
2 - Open sample app
3 - Check if Play Button plugin is appearing in the video
4 - Pause and play the video