### PR TITLE
Improve Fullscreen Button Listeners Handling

### DIFF
--- a/clappr/src/main/kotlin/io/clappr/player/plugin/control/FullscreenButton.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/plugin/control/FullscreenButton.kt
@@ -33,12 +33,16 @@ open class FullscreenButton(core: Core) : ButtonPlugin(core) {
     }
 
     open fun bindCoreEvents() {
-        listenTo(core, InternalEvent.DID_CHANGE_ACTIVE_PLAYBACK.value, Callback.wrap { _ ->
+        val bindEventsCallback = Callback.wrap {
             bindPlaybackEvents()
             updateState()
-        })
-        listenTo(core, InternalEvent.DID_ENTER_FULLSCREEN.value, Callback.wrap { updateState() })
-        listenTo(core, InternalEvent.DID_EXIT_FULLSCREEN.value, Callback.wrap { updateState() })
+        }
+        val updateStateCallback = Callback.wrap { updateState() }
+
+        listenTo(core, InternalEvent.DID_CHANGE_ACTIVE_PLAYBACK.value, bindEventsCallback)
+        listenTo(core, InternalEvent.DID_CHANGE_ACTIVE_CONTAINER.value, bindEventsCallback)
+        listenTo(core, InternalEvent.DID_ENTER_FULLSCREEN.value, updateStateCallback)
+        listenTo(core, InternalEvent.DID_EXIT_FULLSCREEN.value, updateStateCallback)
     }
 
     open fun bindPlaybackEvents() {

--- a/clappr/src/main/kotlin/io/clappr/player/plugin/control/FullscreenButton.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/plugin/control/FullscreenButton.kt
@@ -26,7 +26,7 @@ open class FullscreenButton(core: Core) : ButtonPlugin(core) {
     override val resourceLayout: Int
         get() = R.layout.bottom_panel_button_plugin
 
-    internal val playbackListenerIds = mutableListOf<String>()
+    private val playbackListenerIds = mutableListOf<String>()
 
     init {
         bindCoreEvents()

--- a/clappr/src/test/kotlin/io/clappr/player/plugin/control/FullscreenButtonTest.kt
+++ b/clappr/src/test/kotlin/io/clappr/player/plugin/control/FullscreenButtonTest.kt
@@ -41,38 +41,34 @@ class FullscreenButtonTest {
     }
 
     @Test
-    fun shouldNotHavePlaybackListenersWhenInit() {
-        fullscreenButton = FullscreenButton(core)
+    fun shouldStopListeningOldPlaybackWhenDidChangePlaybackEventIsTriggered() {
+        val oldPlayback = container.playback
 
-        assertTrue(fullscreenButton.playbackListenerIds.size == 0,
-                "Playback listeners should not be registered")
+        assertEquals(View.VISIBLE, fullscreenButton.view.visibility)
+
+        val newPlayback = FakePlayback(stateFake = Playback.State.PLAYING)
+        container.playback = newPlayback
+
+        oldPlayback?.trigger(Event.DID_COMPLETE.value)
+
+        assertEquals(View.VISIBLE, fullscreenButton.view.visibility)
     }
 
     @Test
-    fun shouldBindPlaybackListenersWhenDidChangeActivePlaybackEventIsTriggered() {
-        fullscreenButton.playbackListenerIds.clear()
+    fun shouldStopListeningOldPlaybackWhenDidChangeContainerEventIsTriggered() {
+        val oldContainer = container
 
-        container.playback = FakePlayback()
+        assertEquals(View.VISIBLE, fullscreenButton.view.visibility)
 
-        assertTrue(fullscreenButton.playbackListenerIds.size > 0,
-                "Playback listeners should be registered")
-    }
+        val newContainer = Container(Loader(), Options())
+        val newPlayback = FakePlayback(stateFake = Playback.State.PLAYING)
 
-    @Test
-    fun shouldRemoveAllPlaybackListenersBeforeBindNewOnesWhenDidChangeActivePlaybackEventIsTriggered() {
-        val expectedAmountOfListener = 2
+        newContainer.playback = newPlayback
+        core.activeContainer = newContainer
 
-        container.playback = FakePlayback()
+        oldContainer.playback?.trigger(Event.DID_COMPLETE.value)
 
-        assertEquals(expectedAmountOfListener, fullscreenButton.playbackListenerIds.size)
-    }
-
-    @Test
-    fun shouldRemoveAllPlaybackListenersWhenPluginIsDestroyed() {
-        fullscreenButton.destroy()
-
-        assertTrue(fullscreenButton.playbackListenerIds.size == 0,
-                "Playback listeners should not be registered")
+        assertEquals(View.VISIBLE, fullscreenButton.view.visibility)
     }
 
     @Test

--- a/clappr/src/test/kotlin/io/clappr/player/plugin/control/FullscreenButtonTest.kt
+++ b/clappr/src/test/kotlin/io/clappr/player/plugin/control/FullscreenButtonTest.kt
@@ -41,6 +41,41 @@ class FullscreenButtonTest {
     }
 
     @Test
+    fun shouldNotHavePlaybackListenersWhenInit() {
+        fullscreenButton = FullscreenButton(core)
+
+        assertTrue(fullscreenButton.playbackListenerIds.size == 0,
+                "Playback listeners should not be registered")
+    }
+
+    @Test
+    fun shouldBindPlaybackListenersWhenDidChangeActivePlaybackEventIsTriggered() {
+        fullscreenButton.playbackListenerIds.clear()
+
+        container.playback = FakePlayback()
+
+        assertTrue(fullscreenButton.playbackListenerIds.size > 0,
+                "Playback listeners should be registered")
+    }
+
+    @Test
+    fun shouldRemoveAllPlaybackListenersBeforeBindNewOnesWhenDidChangeActivePlaybackEventIsTriggered() {
+        val expectedAmountOfListener = 2
+
+        container.playback = FakePlayback()
+
+        assertEquals(expectedAmountOfListener, fullscreenButton.playbackListenerIds.size)
+    }
+
+    @Test
+    fun shouldRemoveAllPlaybackListenersWhenPluginIsDestroyed() {
+        fullscreenButton.destroy()
+
+        assertTrue(fullscreenButton.playbackListenerIds.size == 0,
+                "Playback listeners should not be registered")
+    }
+
+    @Test
     fun shouldFullscreenButtonBeVisibleAndNotSelectedWhenEnterFullScreen() {
         triggerDidEnterFullscreen()
 


### PR DESCRIPTION
### Goal
Improve Fullscreen Button listeners handling by stop listening Playback events when plugin is destroyed.

### How to Test
1 - Run Unit Tests
2 - Open sample app
3 - Check if Fullscreen Button plugin is appearing in the video
4 - Click in the Fullscreen button
5 - Check if the Player go fullscreen and the button icon changes
6 - Turn the device to check if the player go portrait and the button changes
7 - Seek to the end of the video
8 - Click in the Play button to restart the video
9 - Check if the Fullscreen button is working as expected