### PR TITLE
Improve Loading Plugin Listeners Handling

### DIFF
--- a/app/src/main/kotlin/io/clappr/player/app/PlayerActivity.kt
+++ b/app/src/main/kotlin/io/clappr/player/app/PlayerActivity.kt
@@ -17,7 +17,7 @@ class  PlayerActivity : Activity() {
     private val playerContainer by lazy { findViewById<ViewGroup>(R.id.player_container) }
     private val changeVideo by lazy { findViewById<Button>(R.id.change_video) }
 
-    private var selectedVideo = 0
+    private var currentVideo = 0
     private val videoList = listOf(
             "http://clappr.io/highline.mp4",
             "https://mnmedias.api.telequebec.tv/m3u8/29880.m3u8",
@@ -54,14 +54,16 @@ class  PlayerActivity : Activity() {
     }
 
     private fun loadVideo() {
-        player.configure(Options(source = videoList[selectedVideo]))
+        player.configure(Options(source = videoList[currentVideo]))
         player.play()
     }
 
     private fun changeVideo() {
-        selectedVideo = (selectedVideo + 1) % videoList.size
+        currentVideo = getNextVideoIndex()
         loadVideo()
     }
+
+    private fun getNextVideoIndex() = (currentVideo + 1) % videoList.size
 
     private fun enterFullscreen() {
         this.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_SENSOR_LANDSCAPE

--- a/app/src/main/kotlin/io/clappr/player/app/PlayerActivity.kt
+++ b/app/src/main/kotlin/io/clappr/player/app/PlayerActivity.kt
@@ -6,6 +6,7 @@ import android.content.res.Configuration
 import android.os.Bundle
 import android.view.View
 import android.view.ViewGroup
+import android.widget.Button
 import io.clappr.player.Player
 import io.clappr.player.base.*
 import io.clappr.player.log.Logger
@@ -14,10 +15,22 @@ class  PlayerActivity : Activity() {
 
     private lateinit var player: Player
     private val playerContainer by lazy { findViewById<ViewGroup>(R.id.player_container) }
+    private val changeVideo by lazy { findViewById<Button>(R.id.change_video) }
+
+    private var selectedVideo = 0
+    private val videoList = listOf(
+            "http://clappr.io/highline.mp4",
+            "https://mnmedias.api.telequebec.tv/m3u8/29880.m3u8",
+            "https://storage.googleapis.com/coverr-main/mp4/Pool-games.mp4",
+            "https://bitdash-a.akamaihd.net/content/MI201109210084_1/m3u8s/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.m3u8"
+
+    )
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_player)
+
+        changeVideo.setOnClickListener { changeVideo() }
 
         player = Player()
         player.on(Event.WILL_PLAY.value, Callback.wrap { Logger.info("App", "Will Play") })
@@ -31,22 +44,30 @@ class  PlayerActivity : Activity() {
             bundle?.getParcelable<ErrorInfo>(Event.ERROR.value)?.let {
                 Logger.error("App","Error: ${it.code} ${it.message}", (it.extras?.getSerializable(ErrorInfoData.EXCEPTION.value) as? Exception))
             }
-
         })
 
         val fragmentTransaction = fragmentManager.beginTransaction()
         fragmentTransaction.add(R.id.player_container, player)
         fragmentTransaction.commit()
 
-        player.configure(Options(source = "http://clappr.io/highline.mp4"))
+        loadVideo()
+    }
+
+    private fun loadVideo() {
+        player.configure(Options(source = videoList[selectedVideo]))
         player.play()
     }
 
-    fun enterFullscreen() {
+    private fun changeVideo() {
+        selectedVideo = (selectedVideo + 1) % videoList.size
+        loadVideo()
+    }
+
+    private fun enterFullscreen() {
         this.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_SENSOR_LANDSCAPE
     }
 
-    fun exitFullscreen() {
+    private fun exitFullscreen() {
         this.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_SENSOR_PORTRAIT
     }
 
@@ -55,7 +76,7 @@ class  PlayerActivity : Activity() {
         checkScreenOrientation(newConfig.orientation)
     }
 
-    fun checkScreenOrientation(orientation: Int) {
+    private fun checkScreenOrientation(orientation: Int) {
         when (orientation) {
             Configuration.ORIENTATION_LANDSCAPE -> {
                 hideSystemUi()

--- a/app/src/main/kotlin/io/clappr/player/app/PlayerActivity.kt
+++ b/app/src/main/kotlin/io/clappr/player/app/PlayerActivity.kt
@@ -7,6 +7,8 @@ import android.os.Bundle
 import android.view.View
 import android.view.ViewGroup
 import android.widget.Button
+import android.widget.EditText
+import android.widget.TextView
 import io.clappr.player.Player
 import io.clappr.player.base.*
 import io.clappr.player.log.Logger
@@ -16,20 +18,13 @@ class  PlayerActivity : Activity() {
     private lateinit var player: Player
     private val playerContainer by lazy { findViewById<ViewGroup>(R.id.player_container) }
     private val changeVideo by lazy { findViewById<Button>(R.id.change_video) }
-
-    private var currentVideo = 0
-    private val videoList = listOf(
-            "http://clappr.io/highline.mp4",
-            "https://mnmedias.api.telequebec.tv/m3u8/29880.m3u8",
-            "https://storage.googleapis.com/coverr-main/mp4/Pool-games.mp4",
-            "https://bitdash-a.akamaihd.net/content/MI201109210084_1/m3u8s/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.m3u8"
-
-    )
+    private val videoUrl by lazy { findViewById<EditText>(R.id.video_url) }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_player)
 
+        videoUrl.setText("http://clappr.io/highline.mp4", TextView.BufferType.EDITABLE)
         changeVideo.setOnClickListener { changeVideo() }
 
         player = Player()
@@ -54,16 +49,13 @@ class  PlayerActivity : Activity() {
     }
 
     private fun loadVideo() {
-        player.configure(Options(source = videoList[currentVideo]))
+        player.configure(Options(source = videoUrl.text.toString()))
         player.play()
     }
 
     private fun changeVideo() {
-        currentVideo = getNextVideoIndex()
         loadVideo()
     }
-
-    private fun getNextVideoIndex() = (currentVideo + 1) % videoList.size
 
     private fun enterFullscreen() {
         this.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_SENSOR_LANDSCAPE

--- a/app/src/main/res/layout/activity_player.xml
+++ b/app/src/main/res/layout/activity_player.xml
@@ -11,9 +11,19 @@
         android:layout_width="match_parent"
         android:layout_height="@dimen/player_portrait_height" />
 
+    <EditText
+        android:id="@+id/video_url"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:inputType="textWebEmailAddress"
+        android:textColor="@color/primary_text_default_material_light"
+        android:hint="@string/hint_video_url"
+        android:singleLine="true" />
+
     <Button
         android:id="@+id/change_video"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:text="@string/change_video"/>
+
 </LinearLayout>

--- a/app/src/main/res/layout/activity_player.xml
+++ b/app/src/main/res/layout/activity_player.xml
@@ -10,4 +10,10 @@
         android:id="@+id/player_container"
         android:layout_width="match_parent"
         android:layout_height="@dimen/player_portrait_height" />
+
+    <Button
+        android:id="@+id/change_video"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/change_video"/>
 </LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -4,5 +4,5 @@
     <string name="title_activity_player">Clappr</string>
     <string name="action_settings">Settings</string>
     <string name="change_video">Change Video</string>
-    <string name="hint_video_url">Enter a video url</string>
+    <string name="hint_video_url">Enter a video URL</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,9 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-
     <string name="app_name">Clappr</string>
     <string name="title_activity_player">Clappr</string>
     <string name="action_settings">Settings</string>
     <string name="change_video">Change Video</string>
-
+    <string name="hint_video_url">Enter a video url</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -4,5 +4,6 @@
     <string name="app_name">Clappr</string>
     <string name="title_activity_player">Clappr</string>
     <string name="action_settings">Settings</string>
+    <string name="change_video">Change Video</string>
 
 </resources>

--- a/clappr/src/test/kotlin/io/clappr/player/plugin/LoadingPluginTest.kt
+++ b/clappr/src/test/kotlin/io/clappr/player/plugin/LoadingPluginTest.kt
@@ -1,0 +1,161 @@
+package io.clappr.player.plugin
+
+import android.view.View
+import android.widget.LinearLayout
+import io.clappr.player.BuildConfig
+import io.clappr.player.base.BaseObject
+import io.clappr.player.base.Event
+import io.clappr.player.base.Options
+import io.clappr.player.components.Container
+import io.clappr.player.components.Core
+import io.clappr.player.components.Playback
+import io.clappr.player.components.PlaybackSupportInterface
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.robolectric.shadows.ShadowApplication
+import kotlin.test.assertEquals
+
+@RunWith(RobolectricTestRunner::class)
+@Config(constants = BuildConfig::class, sdk = [23])
+class LoadingPluginTest {
+
+    private lateinit var loadingPlugin: LoadingPlugin
+    private lateinit var core: Core
+    private lateinit var container: Container
+
+    @Before
+    fun setUp() {
+        BaseObject.context = ShadowApplication.getInstance().applicationContext
+
+        container = Container(Loader(), Options())
+        core = Core(Loader(), Options())
+        loadingPlugin = LoadingPlugin(container)
+
+        core.activeContainer = container
+        container.playback = FakePlayback()
+    }
+
+    @Test
+    fun shouldInitWithStateEnabled() {
+        assertEquals(Plugin.State.ENABLED, loadingPlugin.state)
+    }
+
+    @Test
+    fun shouldStopListeningOldPlaybackWhenDidChangePlaybackEventIsTriggered() {
+        val oldPlayback = container.playback
+
+        assertEquals(UIPlugin.Visibility.HIDDEN, loadingPlugin.visibility)
+
+        val newPlayback = FakePlayback()
+        container.playback = newPlayback
+
+        oldPlayback?.trigger(Event.STALLED.value)
+
+        assertEquals(UIPlugin.Visibility.HIDDEN, loadingPlugin.visibility)
+    }
+
+    @Test
+    fun shouldSetupSpinnerLayout() {
+        val expectedLayoutParams = LinearLayout.LayoutParams.MATCH_PARENT
+        val expectedAlpha = 0.7f
+
+        val spinnerLayout = loadingPlugin.view as? LinearLayout
+
+        assertEquals(expectedLayoutParams, spinnerLayout?.layoutParams?.height)
+        assertEquals(expectedLayoutParams, spinnerLayout?.layoutParams?.width)
+        assertEquals(expectedAlpha, spinnerLayout?.alpha)
+    }
+
+    @Test
+    fun shouldStartAnimationWhenStalledIsTriggered() {
+        setupViewHidden()
+
+        container.playback?.trigger(Event.STALLED.value)
+
+        assertVisibleView()
+    }
+
+    @Test
+    fun shouldStartAnimationWhenWillPlayIsTriggered() {
+        setupViewHidden()
+
+        container.playback?.trigger(Event.WILL_PLAY.value)
+
+        assertVisibleView()
+    }
+
+    @Test
+    fun shouldStopAnimationWhenPlayingIsTriggered() {
+        setupViewVisible()
+
+        container.playback?.trigger(Event.PLAYING.value)
+
+        assertHiddenView()
+    }
+
+    @Test
+    fun shouldStopAnimationWhenDidStopIsTriggered() {
+        setupViewVisible()
+
+        container.playback?.trigger(Event.DID_STOP.value)
+
+        assertHiddenView()
+    }
+
+    @Test
+    fun shouldStopAnimationWhenDidPauseIsTriggered() {
+        setupViewVisible()
+
+        container.playback?.trigger(Event.DID_PAUSE.value)
+
+        assertHiddenView()
+    }
+
+    @Test
+    fun shouldStopAnimationWhenDidCompleteIsTriggered() {
+        setupViewVisible()
+
+        container.playback?.trigger(Event.DID_COMPLETE.value)
+
+        assertHiddenView()
+    }
+
+    @Test
+    fun shouldStopAnimationWhenErrorTriggered() {
+        setupViewVisible()
+
+        container.playback?.trigger(Event.ERROR.value)
+
+        assertHiddenView()
+    }
+
+    private fun setupViewVisible() {
+        loadingPlugin.view?.visibility = View.VISIBLE
+        loadingPlugin.visibility = UIPlugin.Visibility.VISIBLE
+    }
+
+    private fun assertVisibleView() {
+        assertEquals(View.VISIBLE, loadingPlugin.view?.visibility)
+        assertEquals(UIPlugin.Visibility.VISIBLE, loadingPlugin.visibility)
+    }
+
+    private fun setupViewHidden() {
+        loadingPlugin.view?.visibility = View.INVISIBLE
+        loadingPlugin.visibility = UIPlugin.Visibility.HIDDEN
+    }
+
+    private fun assertHiddenView() {
+        assertEquals(View.INVISIBLE, loadingPlugin.view?.visibility)
+        assertEquals(UIPlugin.Visibility.HIDDEN, loadingPlugin.visibility)
+    }
+
+    class FakePlayback(source: String = "aSource", mimeType: String? = null, options: Options = Options()) : Playback(source, mimeType, options) {
+        companion object : PlaybackSupportInterface {
+            override val name: String = "fakePlayback"
+            override fun supportsSource(source: String, mimeType: String?) = true
+        }
+    }
+}


### PR DESCRIPTION
### Goal
Improve Loading Plugin listeners handling by stop listening Playback events when plugin is destroyed.

### How to Test

Start by running the Unit Tests

1 - Open sample app
2 - Check if Loading is appearing in the video
3 - Seek to the middle of the video and check if the loading appears
4 - Seek to the end of the video
5 - Click in the Play button to restart the video
6 - Check if Loading is appearing in the video
7 - Click in the `Change Video` button
8 - Check if a new video is loaded and the Loading is working as expected