### PR TITLE
feat/poster_listeners: remove liteners from PosterPlugin after destroying

### DIFF
--- a/clappr/src/main/kotlin/io/clappr/player/plugin/PosterPlugin.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/plugin/PosterPlugin.kt
@@ -65,6 +65,7 @@ class PosterPlugin(container: Container): UIContainerPlugin(container) {
 
     private fun bindPlaybackListeners() {
         stopPlaybackListeners()
+        updatePoster()
 
         container.playback?.let {
             playbackListenerIds.addAll(listOf(

--- a/clappr/src/main/kotlin/io/clappr/player/plugin/PosterPlugin.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/plugin/PosterPlugin.kt
@@ -28,10 +28,10 @@ class PosterPlugin(container: Container): UIContainerPlugin(container) {
     companion object : NamedType {
         override val name = "poster"
 
-        val httpClient: OkHttpClient by lazy { OkHttpClient.Builder().build() }
-        val picasso: Picasso by lazy {
+        private val httpClient: OkHttpClient by lazy { OkHttpClient.Builder().build() }
+        private val picasso: Picasso by lazy {
             Picasso.Builder(context).downloader(OkHttp3Downloader(httpClient))
-                .listener({ _, uri, _ -> Logger.error(message = "Failed to load image: $uri") })
+                .listener{ _, uri, _ -> Logger.error(message = "Failed to load image: $uri") }
                 .build()
         }
     }
@@ -48,26 +48,31 @@ class PosterPlugin(container: Container): UIContainerPlugin(container) {
     override val view: View?
         get() = posterLayout
 
+    private val playbackListenerIds = mutableListOf<String>()
+
     init {
         updateImageUrlFromOptions()
         setupPosterLayout()
         bindEventListeners()
     }
 
-    fun bindEventListeners() {
+    private fun bindEventListeners() {
         updatePoster()
         listenTo(container, InternalEvent.DID_CHANGE_PLAYBACK.value, Callback.wrap { bindPlaybackListeners() })
         listenTo(container, Event.REQUEST_POSTER_UPDATE.value, Callback.wrap { it -> updatePoster(it) })
         listenTo(container, InternalEvent.DID_UPDATE_OPTIONS.value, Callback.wrap { updateImageUrlFromOptions() })
     }
 
-    fun bindPlaybackListeners() {
+    private fun bindPlaybackListeners() {
         stopListening()
         bindEventListeners()
+
         container.playback?.let {
-            listenTo(it, Event.PLAYING.value, Callback.wrap { hide() })
-            listenTo(it, Event.DID_STOP.value, Callback.wrap { show() })
-            listenTo(it, Event.DID_COMPLETE.value, Callback.wrap { show() })
+            playbackListenerIds.addAll(listOf(
+                listenTo(it, Event.PLAYING.value, Callback.wrap { hide() }),
+                listenTo(it, Event.DID_STOP.value, Callback.wrap { show() }),
+                listenTo(it, Event.DID_COMPLETE.value, Callback.wrap { show() })
+            ))
         }
     }
 
@@ -88,7 +93,7 @@ class PosterPlugin(container: Container): UIContainerPlugin(container) {
         }
     }
 
-    fun updatePoster(bundle: Bundle? = null) {
+    private fun updatePoster(bundle: Bundle? = null) {
         if (bundle != null) {
             val url = bundle.getString("url")
             if (url != null) {
@@ -110,5 +115,15 @@ class PosterPlugin(container: Container): UIContainerPlugin(container) {
             picasso.load(uri).fit().centerCrop().into(imageView)
             container.trigger(Event.DID_UPDATE_POSTER.value)
         }
+    }
+
+    override fun destroy() {
+        stopPlaybackListeners()
+        super.destroy()
+    }
+
+    private fun stopPlaybackListeners() {
+        playbackListenerIds.forEach(::stopListening)
+        playbackListenerIds.clear()
     }
 }

--- a/clappr/src/main/kotlin/io/clappr/player/plugin/PosterPlugin.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/plugin/PosterPlugin.kt
@@ -64,8 +64,7 @@ class PosterPlugin(container: Container): UIContainerPlugin(container) {
     }
 
     private fun bindPlaybackListeners() {
-        stopListening()
-        bindEventListeners()
+        stopPlaybackListeners()
 
         container.playback?.let {
             playbackListenerIds.addAll(listOf(

--- a/clappr/src/test/kotlin/io/clappr/player/plugin/PosterPluginTest.kt
+++ b/clappr/src/test/kotlin/io/clappr/player/plugin/PosterPluginTest.kt
@@ -1,28 +1,45 @@
 package io.clappr.player.plugin
 
+import android.view.View
+import android.widget.LinearLayout
 import io.clappr.player.BuildConfig
-import io.clappr.player.Player
-import io.clappr.player.base.*
+import io.clappr.player.base.BaseObject
+import io.clappr.player.base.ClapprOption
+import io.clappr.player.base.Event
+import io.clappr.player.base.Options
 import io.clappr.player.components.Container
+import io.clappr.player.components.Core
+import io.clappr.player.components.Playback
+import io.clappr.player.components.PlaybackSupportInterface
 import org.junit.After
+import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
-
-import org.junit.Assert.*
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 import org.robolectric.shadows.ShadowApplication
 
 @RunWith(RobolectricTestRunner::class)
-@Config(constants = BuildConfig::class, sdk = intArrayOf(23))
+@Config(constants = BuildConfig::class, sdk = [23])
 class PosterPluginTest {
+
+    private lateinit var posterPlugin: PosterPlugin
+    private lateinit var core: Core
+    private lateinit var container: Container
 
     @Before
     fun setUp() {
-        Player.initialize(ShadowApplication.getInstance().applicationContext)
+        BaseObject.context = ShadowApplication.getInstance().applicationContext
 
         Loader.registerPlugin(PosterPlugin::class)
+
+        container = Container(Loader(), Options())
+        core = Core(Loader(), Options())
+        posterPlugin = PosterPlugin(container)
+
+        core.activeContainer = container
+        container.playback = PosterPluginTest.FakePlayback()
     }
 
     @After
@@ -32,14 +49,101 @@ class PosterPluginTest {
 
     @Test
     fun shouldUpdateImageUrlWhenUpdateOptionsIsTriggered() {
-        val container = Container(Loader(), Options())
-        val posterPlugin = container.plugins.filterIsInstance(PosterPlugin::class.java).first()
         val expectedImageUrl = "image_url"
 
         val option = Options()
-        option.put(ClapprOption.POSTER.value, expectedImageUrl)
+        option[ClapprOption.POSTER.value] = expectedImageUrl
         container.options = option
 
         assertEquals(expectedImageUrl, posterPlugin.posterImageUrl)
+    }
+
+    @Test
+    fun shouldSetupPosterLayout() {
+        val expectedLayoutParams = LinearLayout.LayoutParams.MATCH_PARENT
+
+        val spinnerLayout = posterPlugin.view as? LinearLayout
+
+        kotlin.test.assertEquals(expectedLayoutParams, spinnerLayout?.layoutParams?.height)
+        kotlin.test.assertEquals(expectedLayoutParams, spinnerLayout?.layoutParams?.width)
+    }
+
+    @Test
+    fun shouldShowPosterWhenStopIsTriggered() {
+        setupViewHidden()
+
+        container.playback?.trigger(Event.DID_STOP.value)
+
+        assertVisibleView()
+    }
+
+    @Test
+    fun shouldShowPosterWhenCompleteIsTriggered() {
+        setupViewHidden()
+
+        container.playback?.trigger(Event.DID_COMPLETE.value)
+
+        assertVisibleView()
+    }
+
+    @Test
+    fun shouldHidePosterWhenCompleteIsTriggered() {
+        setupViewVisible()
+
+        container.playback?.trigger(Event.PLAYING.value)
+
+        assertHiddenView()
+    }
+
+    @Test
+    fun shouldStopListeningOldPlaybackWhenDidChangePlaybackEventIsTriggered() {
+        val oldPlayback = container.playback
+        setupViewHidden()
+
+        val newPlayback = PosterPluginTest.FakePlayback()
+        container.playback = newPlayback
+
+        oldPlayback?.trigger(Event.DID_COMPLETE.value)
+
+        assertHiddenView()
+    }
+
+    @Test
+    fun shouldStopListeningOldPlaybackAfterDestroy() {
+        val oldPlayback = container.playback
+        setupViewHidden()
+
+        posterPlugin.destroy()
+
+        oldPlayback?.trigger(Event.DID_COMPLETE.value)
+
+        assertHiddenView()
+    }
+
+    private fun setupViewVisible() {
+        posterPlugin.view?.visibility = View.VISIBLE
+        posterPlugin.visibility = UIPlugin.Visibility.VISIBLE
+    }
+
+    private fun assertVisibleView() {
+        kotlin.test.assertEquals(View.VISIBLE, posterPlugin.view?.visibility)
+        kotlin.test.assertEquals(UIPlugin.Visibility.VISIBLE, posterPlugin.visibility)
+    }
+
+    private fun setupViewHidden() {
+        posterPlugin.view?.visibility = View.GONE
+        posterPlugin.visibility = UIPlugin.Visibility.HIDDEN
+    }
+
+    private fun assertHiddenView() {
+        kotlin.test.assertEquals(View.GONE, posterPlugin.view?.visibility)
+        kotlin.test.assertEquals(UIPlugin.Visibility.HIDDEN, posterPlugin.visibility)
+    }
+    
+    class FakePlayback(source: String = "aSource", mimeType: String? = null, options: Options = Options()) : Playback(source, mimeType, options) {
+        companion object : PlaybackSupportInterface {
+            override val name: String = "fakePlayback"
+            override fun supportsSource(source: String, mimeType: String?) = true
+        }
     }
 }


### PR DESCRIPTION
Goal
---
Improve PosterPlugin listeners handling by stop listening Playback events when plugin is destroyed.

How to Test
1 - Run Unit Tests
2 - Open sample app
3 - Check if poster is appearing in the video
4 - Seek to the end of the video
5 - Check if poster is appearing in the video
6 - Click in the Play button to restart the video
7 - Check if poster is appearing in the video