### PR TITLE
Prevent Player crash when Plugin throw exception

### DIFF
--- a/clappr/src/main/kotlin/io/clappr/player/base/BaseObject.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/base/BaseObject.kt
@@ -6,8 +6,9 @@ import android.content.Intent
 import android.content.IntentFilter
 import android.os.Bundle
 import android.support.v4.content.LocalBroadcastManager
+import io.clappr.player.log.Logger
 
-open class BaseObject() : EventInterface {
+open class BaseObject : EventInterface {
     companion object {
         const val CONTEXT_KEY  = "clappr:baseobject:context"
         const val USERDATA_KEY = "clappr:baseobject:userdata"
@@ -33,7 +34,13 @@ open class BaseObject() : EventInterface {
             val receiver = Utils.broadcastReceiver { _, intent: Intent? ->
                 val objContext = intent?.getStringExtra(CONTEXT_KEY)
                 if (objContext == obj.id) {
-                    handler.invoke(intent.getBundleExtra(USERDATA_KEY))
+                    try {
+                        handler.invoke(intent.getBundleExtra(USERDATA_KEY))
+                    } catch (error: Exception) {
+                        Logger.error(BaseObject::class.simpleName,
+                                "Plugin ${handler.javaClass.name} crashed during invocation of event $eventName",
+                                error)
+                    }
                 }
             }
 

--- a/clappr/src/main/kotlin/io/clappr/player/plugin/Loader.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/plugin/Loader.kt
@@ -5,6 +5,7 @@ import io.clappr.player.base.NamedType
 import io.clappr.player.base.Options
 import io.clappr.player.components.Playback
 import io.clappr.player.components.PlaybackSupportInterface
+import io.clappr.player.log.Logger
 import kotlin.reflect.KClass
 import kotlin.reflect.full.companionObjectInstance
 import kotlin.reflect.full.primaryConstructor
@@ -131,7 +132,10 @@ class Loader(extraPlugins: List<KClass<out Plugin>> = emptyList(), extraPlayback
         val constructor = pluginClass.primaryConstructor
         try {
             plugin = constructor?.call(component) as? Plugin
-        } catch (e: Exception) {
+        } catch (error: Exception) {
+            Logger.error(Loader::class.simpleName,
+                    "Plugin ${pluginClass.simpleName} crashed during initialization",
+                    error)
         }
 
         return plugin

--- a/clappr/src/main/kotlin/io/clappr/player/plugin/Loader.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/plugin/Loader.kt
@@ -5,7 +5,6 @@ import io.clappr.player.base.NamedType
 import io.clappr.player.base.Options
 import io.clappr.player.components.Playback
 import io.clappr.player.components.PlaybackSupportInterface
-import io.clappr.player.log.Logger
 import kotlin.reflect.KClass
 import kotlin.reflect.full.companionObjectInstance
 import kotlin.reflect.full.primaryConstructor
@@ -128,11 +127,11 @@ class Loader(extraPlugins: List<KClass<out Plugin>> = emptyList(), extraPlayback
 
     private fun loadPlugin(component: BaseObject, pluginClass: KClass<out Plugin>) : Plugin? {
         var plugin: Plugin? = null
-        val constructor = pluginClass.primaryConstructor
 
+        val constructor = pluginClass.primaryConstructor
         try {
             plugin = constructor?.call(component) as? Plugin
-        } catch (error: Exception) {
+        } catch (e: Exception) {
         }
 
         return plugin

--- a/clappr/src/main/kotlin/io/clappr/player/plugin/Loader.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/plugin/Loader.kt
@@ -128,14 +128,11 @@ class Loader(extraPlugins: List<KClass<out Plugin>> = emptyList(), extraPlayback
 
     private fun loadPlugin(component: BaseObject, pluginClass: KClass<out Plugin>) : Plugin? {
         var plugin: Plugin? = null
-
         val constructor = pluginClass.primaryConstructor
+
         try {
             plugin = constructor?.call(component) as? Plugin
         } catch (error: Exception) {
-            Logger.error(Loader::class.simpleName,
-                    "Plugin ${pluginClass.simpleName} crashed during initialization",
-                    error)
         }
 
         return plugin


### PR DESCRIPTION
### Goal

Prevent Player crash when Plugin throw exception during event invocation.

### How to test

To test this change we create a plugin that throws Exceptions. To add it in the project, open PlayerActivity.kt in sample app and add this class on top of PlayerActivity:

```kotlin
class BrokenPlugin(core: Core) : MediaControl.Plugin(core) {

    companion object : NamedType {
        override val name: String?
            get() = "broken"
    }

    init {
        listenTo(core, InternalEvent.DID_CHANGE_ACTIVE_PLAYBACK.value, Callback.wrap { throw NullPointerException("I destroyed your Player during Event") })
    }

    override fun destroy() {
        throw NullPointerException("I destroyed your Player during Destroy")
    }

    override fun render() {
        throw NullPointerException("I destroyed your Player during Render")
    }
}
```

Then register the Plugin in the onCreate method of PlayerActivity, right on top of Player initialization:

```kotlin
Loader.registerPlugin(BrokenPlugin::class)
player = Player()
```

#### How it was before

1 - Go to `dev` branch
2 - Run the sample app with the BrokenPlugin registered
3 - The sample app should break because of the exception thrown by the Plugin
4 - Change Broken Plugin to Container Plugin:

```kotlin
class BrokenPlugin(container: Container) : UIContainerPlugin(container) {
...
init {
        listenTo(container, InternalEvent.DID_CHANGE_PLAYBACK.value, Callback.wrap { throw NullPointerException("I destroyed your Player during Event") })
    }
```

5 - Repeat steps 2 and 3

#### How it is now

1 - Go to `feature/handle_broken_plugin` branch
2 - Run the sample app with the BrokenPlugin registered
3 - The sample app should not break
4 - You should see the error caused by the Broken Plugin in Log
5 - Change Broken Plugin to Container Plugin:

```kotlin
class BrokenPlugin(container: Container) : UIContainerPlugin(container) {
...
init {
        listenTo(container, InternalEvent.DID_CHANGE_PLAYBACK.value, Callback.wrap { throw NullPointerException("I destroyed your Player during Event") })
    }
```

6 - Repeat steps 2 and 4

#### Tests

Don't forget to run the project unit tests