### PR TITLE
Hide Media Control on WILL_LOAD_SOURCE

### DIFF
--- a/clappr/src/main/kotlin/io/clappr/player/plugin/control/MediaControl.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/plugin/control/MediaControl.kt
@@ -122,6 +122,7 @@ open class MediaControl(core: Core) : UICorePlugin(core) {
         core.activeContainer?.let {
             containerListenerIds.add(listenTo(it, InternalEvent.ENABLE_MEDIA_CONTROL.value, Callback.wrap { state = State.ENABLED }))
             containerListenerIds.add(listenTo(it, InternalEvent.DISABLE_MEDIA_CONTROL.value, Callback.wrap { state = State.DISABLED }))
+            containerListenerIds.add(listenTo(it, InternalEvent.WILL_LOAD_SOURCE.value, Callback.wrap { hide() }))
         }
     }
 


### PR DESCRIPTION
### Goal
Hide the media control when a new video will load.

### How to Test

Start by running the Unit Tests

1 - Open sample app
2 - Check if the video is playing
3 - Click on `Change Video`
4 - Check if media control was hidden and a new video is loading