### PR TITLE
Start to play a new video without show Media Control

### DIFF
--- a/clappr/src/main/kotlin/io/clappr/player/plugin/control/MediaControl.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/plugin/control/MediaControl.kt
@@ -207,8 +207,7 @@ open class MediaControl(core: Core) : UICorePlugin(core) {
     open fun show(timeout: Long) {
         visibility = Visibility.VISIBLE
         backgroundView.visibility = View.VISIBLE
-        controlsPanel.visibility = View.VISIBLE
-        foregroundControlsPanel.visibility = View.VISIBLE
+        showDefaultMediaControlPanels()
 
         lastInteractionTime = SystemClock.elapsedRealtime()
 
@@ -239,11 +238,16 @@ open class MediaControl(core: Core) : UICorePlugin(core) {
     }
 
     private fun closeModal() {
-        controlsPanel.visibility = View.VISIBLE
-        foregroundControlsPanel.visibility = View.VISIBLE
+        if(modalPanel.visibility == View.VISIBLE)
+            showDefaultMediaControlPanels()
 
         hideModalPanel()
         core.trigger(InternalEvent.DID_CLOSE_MODAL_PANEL.value)
+    }
+
+    private fun showDefaultMediaControlPanels() {
+        controlsPanel.visibility = View.VISIBLE
+        foregroundControlsPanel.visibility = View.VISIBLE
     }
 
     private fun hideModalPanel() {

--- a/clappr/src/main/kotlin/io/clappr/player/plugin/control/MediaControl.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/plugin/control/MediaControl.kt
@@ -256,8 +256,8 @@ open class MediaControl(core: Core) : UICorePlugin(core) {
 
     override fun render() {
         setupPlugins()
-        Handler().post {layoutPlugins()}
-        show()
+        Handler().post { layoutPlugins() }
+        hide()
         hideModalPanel()
     }
 

--- a/clappr/src/test/kotlin/io/clappr/player/plugin/control/MediaControlTest.kt
+++ b/clappr/src/test/kotlin/io/clappr/player/plugin/control/MediaControlTest.kt
@@ -474,6 +474,18 @@ class MediaControlTest {
         assertEquals(View.INVISIBLE, mediaControl.foregroundControlsPanel.visibility)
     }
 
+    @Test
+    fun shouldRenderWithHiddenMediaControl(){
+        fakePlayback.fakeState = Playback.State.PAUSED
+
+        mediaControl.render()
+
+        assertEquals(mediaControl.visibility, UIPlugin.Visibility.HIDDEN)
+        assertEquals(View.INVISIBLE, mediaControl.backgroundView.visibility)
+        assertEquals(View.INVISIBLE, mediaControl.controlsPanel.visibility)
+        assertEquals(View.INVISIBLE, mediaControl.foregroundControlsPanel.visibility)
+    }
+
     private fun setupFakeMediaControlPlugins(panel: Panel, position: Position, sequenceOption: String? = null) {
         FakePlugin.currentPanel = panel
         FakePlugin.currentPosition = position

--- a/clappr/src/test/kotlin/io/clappr/player/plugin/control/MediaControlTest.kt
+++ b/clappr/src/test/kotlin/io/clappr/player/plugin/control/MediaControlTest.kt
@@ -151,6 +151,46 @@ class MediaControlTest {
     }
 
     @Test
+    fun shouldShowControlsPanelWhenModalWasVisibleAndClosed(){
+        triggerOpenModalPanelEvent()
+
+        triggerCloseModalPanelEvent()
+
+        assertEquals(View.VISIBLE, mediaControl.controlsPanel.visibility)
+    }
+
+    @Test
+    fun shouldKeepControlsPanelVisibilityWhenCloseModalEventWasTriggeredWithHiddenModalPanel(){
+        fakePlayback.fakeState = Playback.State.PLAYING
+        mediaControl.hide()
+
+        triggerCloseModalPanelEvent()
+
+        assertEquals(View.INVISIBLE, mediaControl.controlsPanel.visibility)
+    }
+
+    @Test
+    fun shouldShowForegroundControlsPanelWhenModalWasVisibleAndClosed(){
+        triggerOpenModalPanelEvent()
+
+        triggerCloseModalPanelEvent()
+
+        assertEquals(View.VISIBLE, mediaControl.foregroundControlsPanel.visibility)
+    }
+
+
+    @Test
+    fun shouldKeepForegroundControlsPanelVisibilityWhenCloseModalEventWasTriggeredWithHiddenModalPanel(){
+        fakePlayback.fakeState = Playback.State.PLAYING
+        mediaControl.hide()
+
+        triggerCloseModalPanelEvent()
+
+        assertEquals(View.INVISIBLE, mediaControl.foregroundControlsPanel.visibility)
+    }
+
+
+    @Test
     fun shouldSendDidOpenModalPanelEventWhenModalPanelWasOpened() {
         var didOpenModalPanelEventWasSent = false
 


### PR DESCRIPTION
# How to test
1 - Load a video and Media Control should not shown
2 - Click on the screen and make sure that Media Control is there