### PR TITLE
Feature/sample plugins: VideoInfoPlugin

### DIFF
--- a/app/src/main/kotlin/io/clappr/player/app/PlayerActivity.kt
+++ b/app/src/main/kotlin/io/clappr/player/app/PlayerActivity.kt
@@ -8,7 +8,6 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.Button
 import android.widget.EditText
-import android.widget.TextView
 import io.clappr.player.Player
 import io.clappr.player.app.plugin.NextVideoPlugin
 import io.clappr.player.app.plugin.VideoInfoPlugin
@@ -29,9 +28,9 @@ class  PlayerActivity : Activity() {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_player)
 
-        videoUrl.setText("http://clappr.io/highline.mp4", TextView.BufferType.EDITABLE)
-        videoTitle.setText("Highline", TextView.BufferType.EDITABLE)
-        videoSubtitle.setText("Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.", TextView.BufferType.EDITABLE)
+        videoUrl.setText("http://clappr.io/highline.mp4")
+        videoTitle.setText(getString(R.string.video_title))
+        videoSubtitle.setText(getString(R.string.video_subtitle))
 
         changeVideo.setOnClickListener { changeVideo() }
 

--- a/app/src/main/kotlin/io/clappr/player/app/PlayerActivity.kt
+++ b/app/src/main/kotlin/io/clappr/player/app/PlayerActivity.kt
@@ -11,6 +11,7 @@ import android.widget.EditText
 import android.widget.TextView
 import io.clappr.player.Player
 import io.clappr.player.app.plugin.NextVideoPlugin
+import io.clappr.player.app.plugin.VideoInfoPlugin
 import io.clappr.player.base.*
 import io.clappr.player.log.Logger
 import io.clappr.player.plugin.Loader
@@ -21,15 +22,21 @@ class  PlayerActivity : Activity() {
     private val playerContainer by lazy { findViewById<ViewGroup>(R.id.player_container) }
     private val changeVideo by lazy { findViewById<Button>(R.id.change_video) }
     private val videoUrl by lazy { findViewById<EditText>(R.id.video_url) }
+    private val videoTitle by lazy { findViewById<EditText>(R.id.video_title) }
+    private val videoSubtitle by lazy { findViewById<EditText>(R.id.video_subtitle) }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_player)
 
         videoUrl.setText("http://clappr.io/highline.mp4", TextView.BufferType.EDITABLE)
+        videoTitle.setText("Highline", TextView.BufferType.EDITABLE)
+        videoSubtitle.setText("Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.", TextView.BufferType.EDITABLE)
+
         changeVideo.setOnClickListener { changeVideo() }
 
         Loader.registerPlugin(NextVideoPlugin::class)
+        Loader.registerPlugin(VideoInfoPlugin::class)
 
         player = Player()
         player.on(Event.WILL_PLAY.value, Callback.wrap { Logger.info("App", "Will Play") })
@@ -53,7 +60,15 @@ class  PlayerActivity : Activity() {
     }
 
     private fun loadVideo() {
-        player.configure(Options(source = videoUrl.text.toString()))
+        val url = videoUrl.text.toString()
+        val title = videoTitle.text.toString()
+        val subtitle = videoSubtitle.text.toString()
+
+        val options = java.util.HashMap<String, Any>()
+        options[VideoInfoPlugin.Option.TITLE.value] = title
+        options[VideoInfoPlugin.Option.SUBTITLE.value] = subtitle
+
+        player.configure(Options(source = url, options = options))
         player.play()
     }
 

--- a/app/src/main/kotlin/io/clappr/player/app/plugin/NextVideoPlugin.kt
+++ b/app/src/main/kotlin/io/clappr/player/app/plugin/NextVideoPlugin.kt
@@ -39,11 +39,6 @@ open class NextVideoPlugin(core: Core) : UICorePlugin(core) {
         bindCoreEvents()
     }
 
-    override fun destroy() {
-        stopPlaybackListeners()
-        super.destroy()
-    }
-
     override fun render() {
         super.render()
         setupLayout()

--- a/app/src/main/kotlin/io/clappr/player/app/plugin/VideoInfoPlugin.kt
+++ b/app/src/main/kotlin/io/clappr/player/app/plugin/VideoInfoPlugin.kt
@@ -1,0 +1,88 @@
+package io.clappr.player.app.plugin
+
+import android.support.annotation.Keep
+import android.view.LayoutInflater
+import android.view.View
+import android.widget.LinearLayout
+import android.widget.TextView
+import io.clappr.player.app.R
+import io.clappr.player.base.Callback
+import io.clappr.player.base.Event
+import io.clappr.player.base.InternalEvent
+import io.clappr.player.base.NamedType
+import io.clappr.player.components.Core
+import io.clappr.player.plugin.control.MediaControl
+
+open class VideoInfoPlugin(core: Core) : MediaControl.Plugin(core) {
+
+    enum class Option(val value: String) {
+        TITLE("$name:title"),
+
+        SUBTITLE("$name:subtitle")
+    }
+
+    @Keep
+    companion object : NamedType {
+        override val name: String?
+            get() = "videoInfo"
+    }
+
+    override var panel: Panel = Panel.TOP
+
+    override var position: Position = Position.LEFT
+
+    override val view by lazy {
+        LayoutInflater.from(context).inflate(R.layout.video_info_plugin, null) as LinearLayout
+    }
+
+    open val titleLabel by lazy { view.findViewById(R.id.title_label) as TextView }
+
+    open val subtitleLabel by lazy { view.findViewById(R.id.subtitle_label) as TextView }
+
+    private val playbackListenerIds = mutableListOf<String>()
+
+    private val title
+            get() = core.activeContainer?.options?.get(Option.TITLE.value) as? String
+
+    private val subtitle
+            get() = core.activeContainer?.options?.get(Option.SUBTITLE.value) as? String
+
+    init {
+        bindCoreEvents()
+    }
+
+    override fun render() {
+        super.render()
+        show()
+    }
+
+    private fun bindCoreEvents() {
+        listenTo(core, InternalEvent.DID_CHANGE_ACTIVE_PLAYBACK.value, Callback.wrap { bindPlaybackEvents() })
+        listenTo(core, InternalEvent.DID_ENTER_FULLSCREEN.value, Callback.wrap { updateVideoInfo() })
+        listenTo(core, InternalEvent.DID_EXIT_FULLSCREEN.value, Callback.wrap { updateVideoInfo() })
+    }
+
+    private fun bindPlaybackEvents() {
+        stopPlaybackListeners()
+        updateVideoInfo()
+        core.activePlayback?.let {
+            playbackListenerIds.add(listenTo(it, Event.DID_COMPLETE.value, Callback.wrap { hide() }))
+        }
+    }
+
+    private fun updateVideoInfo() {
+        titleLabel.text = title
+        subtitleLabel.text = subtitle
+
+        if (core.fullscreenState == Core.FullscreenState.FULLSCREEN) {
+            subtitleLabel.visibility = View.VISIBLE
+        } else {
+            subtitleLabel.visibility = View.GONE
+        }
+    }
+
+    private fun stopPlaybackListeners() {
+        playbackListenerIds.forEach(::stopListening)
+        playbackListenerIds.clear()
+    }
+}

--- a/app/src/main/kotlin/io/clappr/player/app/plugin/VideoInfoPlugin.kt
+++ b/app/src/main/kotlin/io/clappr/player/app/plugin/VideoInfoPlugin.kt
@@ -60,21 +60,25 @@ open class VideoInfoPlugin(core: Core) : MediaControl.Plugin(core) {
     private fun bindPlaybackEvents() {
         hide()
         stopPlaybackListeners()
-        updateVideoInfo()
         core.activePlayback?.let {
             playbackListenerIds.add(listenTo(it, Event.WILL_PLAY.value, Callback.wrap { show() }))
         }
+    }
+
+    override fun render() {
+        updateVideoInfo()
+        super.render()
     }
 
     private fun updateVideoInfo() {
         titleLabel.text = title
         subtitleLabel.text = subtitle
 
-        if (core.fullscreenState == Core.FullscreenState.FULLSCREEN) {
-            subtitleLabel.visibility = View.VISIBLE
-        } else {
-            subtitleLabel.visibility = View.GONE
-        }
+        subtitleLabel.visibility =
+                if (core.fullscreenState == Core.FullscreenState.FULLSCREEN)
+                    View.VISIBLE
+                else
+                    View.GONE
     }
 
     private fun stopPlaybackListeners() {

--- a/app/src/main/kotlin/io/clappr/player/app/plugin/VideoInfoPlugin.kt
+++ b/app/src/main/kotlin/io/clappr/player/app/plugin/VideoInfoPlugin.kt
@@ -51,11 +51,6 @@ open class VideoInfoPlugin(core: Core) : MediaControl.Plugin(core) {
         bindCoreEvents()
     }
 
-    override fun render() {
-        super.render()
-        show()
-    }
-
     private fun bindCoreEvents() {
         listenTo(core, InternalEvent.DID_CHANGE_ACTIVE_PLAYBACK.value, Callback.wrap { bindPlaybackEvents() })
         listenTo(core, InternalEvent.DID_ENTER_FULLSCREEN.value, Callback.wrap { updateVideoInfo() })
@@ -63,10 +58,11 @@ open class VideoInfoPlugin(core: Core) : MediaControl.Plugin(core) {
     }
 
     private fun bindPlaybackEvents() {
+        hide()
         stopPlaybackListeners()
         updateVideoInfo()
         core.activePlayback?.let {
-            playbackListenerIds.add(listenTo(it, Event.DID_COMPLETE.value, Callback.wrap { hide() }))
+            playbackListenerIds.add(listenTo(it, Event.WILL_PLAY.value, Callback.wrap { show() }))
         }
     }
 

--- a/app/src/main/res/layout/activity_player.xml
+++ b/app/src/main/res/layout/activity_player.xml
@@ -20,6 +20,22 @@
         android:hint="@string/hint_video_url"
         android:singleLine="true" />
 
+    <EditText
+        android:id="@+id/video_title"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:textColor="@color/primary_text_default_material_light"
+        android:hint="@string/hint_video_title"
+        android:singleLine="true" />
+
+    <EditText
+        android:id="@+id/video_subtitle"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:textColor="@color/primary_text_default_material_light"
+        android:hint="@string/hint_video_subtitle"
+        android:inputType="textMultiLine" />
+
     <Button
         android:id="@+id/change_video"
         android:layout_width="wrap_content"

--- a/app/src/main/res/layout/video_info_plugin.xml
+++ b/app/src/main/res/layout/video_info_plugin.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="horizontal"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content">
+
+    <LinearLayout
+        android:id="@+id/info_panel"
+        android:orientation="vertical"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="bottom"
+        android:layout_marginEnd="@dimen/video_info_title_right_margin"
+        android:layout_marginRight="@dimen/video_info_title_right_margin">
+
+        <TextView
+            android:id="@+id/title_label"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/video_info_title_top_margin"
+            android:textColor="@color/video_info_text_color"
+            android:textSize="@dimen/video_info_title_font_size"
+            android:ellipsize="end"
+            android:lines="1"/>
+
+        <TextView
+            android:id="@+id/subtitle_label"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/video_info_subtitle_top_margin"
+            android:textColor="@color/video_info_text_color"
+            android:textSize="@dimen/video_info_subtitle_font_size"
+            android:ellipsize="end"
+            android:lines="1"/>
+
+    </LinearLayout>
+
+</LinearLayout>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -12,4 +12,10 @@
     <dimen name="next_video_plugin_icon_play_height">30dp</dimen>
     <dimen name="next_video_plugin_label_padding">10dp</dimen>
     <dimen name="next_video_plugin_font_size">15sp</dimen>
+
+    <dimen name="video_info_title_font_size">18sp</dimen>
+    <dimen name="video_info_title_top_margin">-4dp</dimen>
+    <dimen name="video_info_subtitle_font_size">14sp</dimen>
+    <dimen name="video_info_subtitle_top_margin">6dp</dimen>
+    <dimen name="video_info_title_right_margin">10dp</dimen>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -8,4 +8,6 @@
     <string name="hint_video_title">Enter a video title</string>
     <string name="hint_video_subtitle">Enter a video subtitle</string>
     <string name="play_next_video">Play Next Video:</string>
+    <string name="video_title">Video Title</string>
+    <string name="video_subtitle">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -5,5 +5,7 @@
     <string name="action_settings">Settings</string>
     <string name="change_video">Change Video</string>
     <string name="hint_video_url">Enter a video URL</string>
+    <string name="hint_video_title">Enter a video title</string>
+    <string name="hint_video_subtitle">Enter a video subtitle</string>
     <string name="play_next_video">Play Next Video:</string>
 </resources>

--- a/app/src/test/kotlin/io/clappr/player/app/plugin/NextVideoPluginTest.kt
+++ b/app/src/test/kotlin/io/clappr/player/app/plugin/NextVideoPluginTest.kt
@@ -10,6 +10,7 @@ import io.clappr.player.app.plugin.util.assertShown
 import io.clappr.player.base.BaseObject
 import io.clappr.player.base.Event
 import io.clappr.player.base.Options
+import io.clappr.player.components.Container
 import io.clappr.player.components.Core
 import io.clappr.player.plugin.Loader
 import io.clappr.player.plugin.UIPlugin
@@ -36,16 +37,18 @@ class NextVideoPluginTest {
     fun setup() {
         BaseObject.context = ShadowApplication.getInstance().applicationContext
 
-        Loader.registerPlayback(FakePlayback::class)
-        Loader.registerPlugin(NextVideoPlugin::class)
-
         core = Core(Loader(), Options(source = source))
 
-        nextVideoPlugin = NextVideoPlugin(core).apply {
-            render()
-        }
+        nextVideoPlugin = NextVideoPlugin(core)
 
-        core.load()
+        //Trigger Container change events
+        val container = Container(core.loader, core.options)
+        core.activeContainer  = container
+
+        //Trigger Playback change events
+        container.playback = FakePlayback("")
+
+        nextVideoPlugin.render()
     }
 
     @Test

--- a/app/src/test/kotlin/io/clappr/player/app/plugin/NextVideoPluginTest.kt
+++ b/app/src/test/kotlin/io/clappr/player/app/plugin/NextVideoPluginTest.kt
@@ -1,11 +1,12 @@
 package io.clappr.player.app.plugin
 
 import android.app.Application
-import android.view.View
 import android.widget.LinearLayout
 import io.clappr.player.BuildConfig
 import io.clappr.player.app.R
 import io.clappr.player.app.plugin.util.FakePlayback
+import io.clappr.player.app.plugin.util.assertHidden
+import io.clappr.player.app.plugin.util.assertShown
 import io.clappr.player.base.BaseObject
 import io.clappr.player.base.Event
 import io.clappr.player.base.Options
@@ -47,7 +48,7 @@ class NextVideoPluginTest {
 
     @Test
     fun shouldHideAfterDidChangePlaybackEventIsTriggered() {
-        assertHidden()
+        assertHidden(nextVideoPlugin)
     }
 
     @Test
@@ -56,21 +57,21 @@ class NextVideoPluginTest {
 
         core.activeContainer?.playback?.trigger(Event.WILL_PLAY.value)
 
-        assertHidden()
+        assertHidden(nextVideoPlugin)
     }
 
     @Test
     fun shouldShowViewWhenDidCompleteEventIsTriggered() {
         core.activeContainer?.playback?.trigger(Event.DID_COMPLETE.value)
 
-        assertShown()
+        assertShown(nextVideoPlugin)
     }
 
     @Test
     fun shouldShowViewWhenDidStopEventIsTriggered() {
         core.activeContainer?.playback?.trigger(Event.DID_STOP.value)
 
-        assertShown()
+        assertShown(nextVideoPlugin)
     }
 
     @Test
@@ -80,7 +81,7 @@ class NextVideoPluginTest {
         val newPlayback = FakePlayback(source)
         core.activeContainer?.playback = newPlayback
 
-        assertHidden()
+        assertHidden(nextVideoPlugin)
     }
 
     @Test
@@ -112,15 +113,5 @@ class NextVideoPluginTest {
     fun shouldContainVideoItemsAfterRender() {
         nextVideoPlugin.render()
         assertTrue(nextVideoPlugin.view.findViewById<LinearLayout>(R.id.video_list).childCount > 0)
-    }
-
-    private fun assertHidden() {
-        assertEquals(UIPlugin.Visibility.HIDDEN, nextVideoPlugin.visibility)
-        assertEquals(View.GONE, nextVideoPlugin.view.visibility)
-    }
-
-    private fun assertShown() {
-        assertEquals(UIPlugin.Visibility.VISIBLE, nextVideoPlugin.visibility)
-        assertEquals(View.VISIBLE, nextVideoPlugin.view.visibility)
     }
 }

--- a/app/src/test/kotlin/io/clappr/player/app/plugin/NextVideoPluginTest.kt
+++ b/app/src/test/kotlin/io/clappr/player/app/plugin/NextVideoPluginTest.kt
@@ -41,9 +41,16 @@ class NextVideoPluginTest {
 
         core = Core(Loader(), Options(source = source))
 
-        nextVideoPlugin = NextVideoPlugin(core)
+        nextVideoPlugin = NextVideoPlugin(core).apply {
+            render()
+        }
 
         core.load()
+    }
+
+    @Test
+    fun shouldContainVideoItemsAfterRendering() {
+        assertTrue(nextVideoPlugin.view.findViewById<LinearLayout>(R.id.video_list).childCount > 0)
     }
 
     @Test
@@ -107,11 +114,5 @@ class NextVideoPluginTest {
         oldPlayback?.trigger(Event.DID_COMPLETE.value)
 
         assertEquals(UIPlugin.Visibility.HIDDEN, nextVideoPlugin.visibility)
-    }
-
-    @Test
-    fun shouldContainVideoItemsAfterRender() {
-        nextVideoPlugin.render()
-        assertTrue(nextVideoPlugin.view.findViewById<LinearLayout>(R.id.video_list).childCount > 0)
     }
 }

--- a/app/src/test/kotlin/io/clappr/player/app/plugin/NextVideoPluginTest.kt
+++ b/app/src/test/kotlin/io/clappr/player/app/plugin/NextVideoPluginTest.kt
@@ -5,12 +5,11 @@ import android.view.View
 import android.widget.LinearLayout
 import io.clappr.player.BuildConfig
 import io.clappr.player.app.R
+import io.clappr.player.app.plugin.util.FakePlayback
 import io.clappr.player.base.BaseObject
 import io.clappr.player.base.Event
 import io.clappr.player.base.Options
 import io.clappr.player.components.Core
-import io.clappr.player.components.Playback
-import io.clappr.player.components.PlaybackSupportInterface
 import io.clappr.player.plugin.Loader
 import io.clappr.player.plugin.UIPlugin
 import org.junit.Before
@@ -123,12 +122,5 @@ class NextVideoPluginTest {
     private fun assertShown() {
         assertEquals(UIPlugin.Visibility.VISIBLE, nextVideoPlugin.visibility)
         assertEquals(View.VISIBLE, nextVideoPlugin.view.visibility)
-    }
-
-    internal class FakePlayback(source: String, mimeType: String? = null, options: Options = Options()) : Playback(source, mimeType, options) {
-        companion object : PlaybackSupportInterface {
-            override val name: String = "fakePlayback"
-            override fun supportsSource(source: String, mimeType: String?) = true
-        }
     }
 }

--- a/app/src/test/kotlin/io/clappr/player/app/plugin/VideoInfoPluginTest.kt
+++ b/app/src/test/kotlin/io/clappr/player/app/plugin/VideoInfoPluginTest.kt
@@ -97,32 +97,32 @@ class VideoInfoPluginTest {
     }
 
     @Test
-    fun shouldShowViewAfterDidChangePlaybackEventIsTriggered() {
+    fun shouldHideViewAfterDidChangePlaybackEventIsTriggered() {
         val newPlayback = FakePlayback(source)
         core.activeContainer?.playback = newPlayback
 
-        assertShown(videoInfoPlugin)
+        assertHidden(videoInfoPlugin)
     }
 
     @Test
-    fun shouldHideViewWhenDidCompleteEventIsTriggered() {
-        core.activeContainer?.playback?.trigger(Event.DID_COMPLETE.value)
+    fun shouldShowViewWhenWillPlayEventIsTriggered() {
+        core.activeContainer?.playback?.trigger(Event.WILL_PLAY.value)
 
-        assertHidden(videoInfoPlugin)
+        assertShown(videoInfoPlugin)
     }
 
     @Test
     fun shouldStopListeningOldPlaybackWhenDidChangePlaybackEventIsTriggered() {
         val oldPlayback = core.activePlayback
 
-        assertEquals(UIPlugin.Visibility.VISIBLE, videoInfoPlugin.visibility)
+        assertHidden(videoInfoPlugin)
 
         val newPlayback = FakePlayback(source)
         core.activeContainer?.playback = newPlayback
 
-        oldPlayback?.trigger(Event.DID_COMPLETE.value)
+        oldPlayback?.trigger(Event.WILL_PLAY.value)
 
-        assertEquals(UIPlugin.Visibility.VISIBLE, videoInfoPlugin.visibility)
+        assertHidden(videoInfoPlugin)
     }
 
     @Test
@@ -131,8 +131,8 @@ class VideoInfoPluginTest {
 
         videoInfoPlugin.destroy()
 
-        oldPlayback?.trigger(Event.DID_COMPLETE.value)
+        oldPlayback?.trigger(Event.WILL_PLAY.value)
 
-        assertEquals(UIPlugin.Visibility.VISIBLE, videoInfoPlugin.visibility)
+        assertHidden(videoInfoPlugin)
     }
 }

--- a/app/src/test/kotlin/io/clappr/player/app/plugin/VideoInfoPluginTest.kt
+++ b/app/src/test/kotlin/io/clappr/player/app/plugin/VideoInfoPluginTest.kt
@@ -2,7 +2,6 @@ package io.clappr.player.app.plugin
 
 import android.app.Application
 import android.view.View
-import android.widget.LinearLayout
 import android.widget.TextView
 import io.clappr.player.BuildConfig
 import io.clappr.player.app.R
@@ -12,9 +11,9 @@ import io.clappr.player.app.plugin.util.assertShown
 import io.clappr.player.base.BaseObject
 import io.clappr.player.base.Event
 import io.clappr.player.base.Options
+import io.clappr.player.components.Container
 import io.clappr.player.components.Core
 import io.clappr.player.plugin.Loader
-import io.clappr.player.plugin.UIPlugin
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -23,7 +22,6 @@ import org.robolectric.annotation.Config
 import org.robolectric.shadows.ShadowApplication
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
-import kotlin.test.assertTrue
 
 @RunWith(RobolectricTestRunner::class)
 @Config(constants = BuildConfig::class, sdk = [23], application = Application::class)
@@ -41,20 +39,22 @@ class VideoInfoPluginTest {
     fun setup() {
         BaseObject.context = ShadowApplication.getInstance().applicationContext
 
-        Loader.registerPlayback(FakePlayback::class)
-        Loader.registerPlugin(VideoInfoPlugin::class)
-
         val options = HashMap<String, Any>()
         options[VideoInfoPlugin.Option.TITLE.value] = title
         options[VideoInfoPlugin.Option.SUBTITLE.value] = subtitle
 
         core = Core(Loader(), Options(source = source, options = options))
 
-        videoInfoPlugin = VideoInfoPlugin(core).apply {
-            render()
-        }
+        videoInfoPlugin = VideoInfoPlugin(core)
 
-        core.load()
+        //Trigger Container change events
+        val container = Container(core.loader, core.options)
+        core.activeContainer  = container
+
+        //Trigger Playback change events
+        container.playback = FakePlayback("")
+
+        videoInfoPlugin.render()
     }
 
     @Test

--- a/app/src/test/kotlin/io/clappr/player/app/plugin/VideoInfoPluginTest.kt
+++ b/app/src/test/kotlin/io/clappr/player/app/plugin/VideoInfoPluginTest.kt
@@ -1,0 +1,138 @@
+package io.clappr.player.app.plugin
+
+import android.app.Application
+import android.view.View
+import android.widget.LinearLayout
+import android.widget.TextView
+import io.clappr.player.BuildConfig
+import io.clappr.player.app.R
+import io.clappr.player.app.plugin.util.FakePlayback
+import io.clappr.player.app.plugin.util.assertHidden
+import io.clappr.player.app.plugin.util.assertShown
+import io.clappr.player.base.BaseObject
+import io.clappr.player.base.Event
+import io.clappr.player.base.Options
+import io.clappr.player.components.Core
+import io.clappr.player.plugin.Loader
+import io.clappr.player.plugin.UIPlugin
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.robolectric.shadows.ShadowApplication
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+@RunWith(RobolectricTestRunner::class)
+@Config(constants = BuildConfig::class, sdk = [23], application = Application::class)
+class VideoInfoPluginTest {
+
+    private lateinit var core: Core
+
+    private lateinit var videoInfoPlugin: VideoInfoPlugin
+
+    private val source = "url"
+    private val title = "title"
+    private val subtitle = "subtitle"
+
+    @Before
+    fun setup() {
+        BaseObject.context = ShadowApplication.getInstance().applicationContext
+
+        Loader.registerPlayback(FakePlayback::class)
+        Loader.registerPlugin(VideoInfoPlugin::class)
+
+        val options = HashMap<String, Any>()
+        options[VideoInfoPlugin.Option.TITLE.value] = title
+        options[VideoInfoPlugin.Option.SUBTITLE.value] = subtitle
+
+        core = Core(Loader(), Options(source = source, options = options))
+
+        videoInfoPlugin = VideoInfoPlugin(core).apply {
+            render()
+        }
+
+        core.load()
+    }
+
+    @Test
+    fun shouldContainTitleAndSubtitleAfterRendering() {
+        videoInfoPlugin.view.findViewById<TextView>(R.id.title_label).let {
+            assertNotNull(it)
+            assertEquals(title, it.text.toString())
+        }
+
+        videoInfoPlugin.view.findViewById<TextView>(R.id.subtitle_label).let {
+            assertNotNull(it)
+            assertEquals(subtitle, it.text.toString())
+        }
+    }
+
+    @Test
+    fun shouldShowTitleAndHideSubtitleOnEmbedded() {
+        core.fullscreenState = Core.FullscreenState.EMBEDDED
+
+        videoInfoPlugin.view.findViewById<TextView>(R.id.title_label).apply {
+            assertEquals(View.VISIBLE, this.visibility)
+        }
+
+        videoInfoPlugin.view.findViewById<TextView>(R.id.subtitle_label).apply {
+            assertEquals(View.GONE, this.visibility)
+        }
+    }
+
+    @Test
+    fun shouldShowTitleAndHideSubtitleOnFullScreen() {
+        core.fullscreenState = Core.FullscreenState.FULLSCREEN
+
+        videoInfoPlugin.view.findViewById<TextView>(R.id.title_label).apply {
+            assertEquals(View.VISIBLE, this.visibility)
+        }
+
+        videoInfoPlugin.view.findViewById<TextView>(R.id.subtitle_label).apply {
+            assertEquals(View.VISIBLE, this.visibility)
+        }
+    }
+
+    @Test
+    fun shouldShowViewAfterDidChangePlaybackEventIsTriggered() {
+        val newPlayback = FakePlayback(source)
+        core.activeContainer?.playback = newPlayback
+
+        assertShown(videoInfoPlugin)
+    }
+
+    @Test
+    fun shouldHideViewWhenDidCompleteEventIsTriggered() {
+        core.activeContainer?.playback?.trigger(Event.DID_COMPLETE.value)
+
+        assertHidden(videoInfoPlugin)
+    }
+
+    @Test
+    fun shouldStopListeningOldPlaybackWhenDidChangePlaybackEventIsTriggered() {
+        val oldPlayback = core.activePlayback
+
+        assertEquals(UIPlugin.Visibility.VISIBLE, videoInfoPlugin.visibility)
+
+        val newPlayback = FakePlayback(source)
+        core.activeContainer?.playback = newPlayback
+
+        oldPlayback?.trigger(Event.DID_COMPLETE.value)
+
+        assertEquals(UIPlugin.Visibility.VISIBLE, videoInfoPlugin.visibility)
+    }
+
+    @Test
+    fun shouldStopListeningOldPlaybackWhenPluginIsDestroyed() {
+        val oldPlayback = core.activePlayback
+
+        videoInfoPlugin.destroy()
+
+        oldPlayback?.trigger(Event.DID_COMPLETE.value)
+
+        assertEquals(UIPlugin.Visibility.VISIBLE, videoInfoPlugin.visibility)
+    }
+}

--- a/app/src/test/kotlin/io/clappr/player/app/plugin/util/Extensions.kt
+++ b/app/src/test/kotlin/io/clappr/player/app/plugin/util/Extensions.kt
@@ -1,0 +1,15 @@
+package io.clappr.player.app.plugin.util
+
+import android.view.View
+import io.clappr.player.plugin.UIPlugin
+import kotlin.test.assertEquals
+
+fun assertHidden(plugin: UIPlugin) {
+    assertEquals(UIPlugin.Visibility.HIDDEN, plugin.visibility)
+    assertEquals(View.GONE, plugin.view?.visibility)
+}
+
+fun assertShown(plugin: UIPlugin) {
+    assertEquals(UIPlugin.Visibility.VISIBLE, plugin.visibility)
+    assertEquals(View.VISIBLE, plugin.view?.visibility)
+}

--- a/app/src/test/kotlin/io/clappr/player/app/plugin/util/FakePlayback.kt
+++ b/app/src/test/kotlin/io/clappr/player/app/plugin/util/FakePlayback.kt
@@ -1,0 +1,13 @@
+package io.clappr.player.app.plugin.util
+
+import io.clappr.player.base.Options
+import io.clappr.player.components.Playback
+import io.clappr.player.components.PlaybackSupportInterface
+
+
+internal class FakePlayback(source: String, mimeType: String? = null, options: Options = Options()) : Playback(source, mimeType, options) {
+    companion object : PlaybackSupportInterface {
+        override val name: String = "fakePlayback"
+        override fun supportsSource(source: String, mimeType: String?) = true
+    }
+}


### PR DESCRIPTION
Goal
----
Add external plugin to Player.

- `VideoInfoPlugin` is a `MediaControl.Plugin` to show title and subtitle if informed by Options

How to Test
----
- open clappr app
- for both fullscreen and embedded modes, every time media control is clicked, title should be shown.
- only on fullscreen mode, every time media control is clicked, subtitle should be shown.