### PR TITLE
Feature/sample UIContainerPlugin

### DIFF
--- a/app/src/main/kotlin/io/clappr/player/app/PlayerActivity.kt
+++ b/app/src/main/kotlin/io/clappr/player/app/PlayerActivity.kt
@@ -10,6 +10,7 @@ import android.widget.Button
 import android.widget.EditText
 import io.clappr.player.Player
 import io.clappr.player.app.plugin.NextVideoPlugin
+import io.clappr.player.app.plugin.PlaybackStatusPlugin
 import io.clappr.player.app.plugin.VideoInfoPlugin
 import io.clappr.player.base.*
 import io.clappr.player.log.Logger
@@ -34,8 +35,7 @@ class  PlayerActivity : Activity() {
 
         changeVideo.setOnClickListener { changeVideo() }
 
-        Loader.registerPlugin(NextVideoPlugin::class)
-        Loader.registerPlugin(VideoInfoPlugin::class)
+        registerExternalPlugins()
 
         player = Player()
         player.on(Event.WILL_PLAY.value, Callback.wrap { Logger.info("App", "Will Play") })
@@ -56,6 +56,12 @@ class  PlayerActivity : Activity() {
         fragmentTransaction.commit()
 
         loadVideo()
+    }
+
+    private fun registerExternalPlugins() {
+        Loader.registerPlugin(NextVideoPlugin::class)
+        Loader.registerPlugin(VideoInfoPlugin::class)
+        Loader.registerPlugin(PlaybackStatusPlugin::class)
     }
 
     private fun loadVideo() {

--- a/app/src/main/kotlin/io/clappr/player/app/plugin/NextVideoPlugin.kt
+++ b/app/src/main/kotlin/io/clappr/player/app/plugin/NextVideoPlugin.kt
@@ -10,8 +10,7 @@ import io.clappr.player.base.*
 import io.clappr.player.components.Core
 import io.clappr.player.plugin.core.UICorePlugin
 
-
-open class NextVideoPlugin(core: Core) : UICorePlugin(core) {
+class NextVideoPlugin(core: Core) : UICorePlugin(core) {
 
     companion object : NamedType {
         override val name = "nextVideo"

--- a/app/src/main/kotlin/io/clappr/player/app/plugin/PlaybackStatusPlugin.kt
+++ b/app/src/main/kotlin/io/clappr/player/app/plugin/PlaybackStatusPlugin.kt
@@ -1,0 +1,66 @@
+package io.clappr.player.app.plugin
+
+import android.view.LayoutInflater
+import android.widget.ImageView
+import android.widget.LinearLayout
+import android.widget.RelativeLayout
+import android.widget.TextView
+import com.squareup.picasso.Picasso
+import io.clappr.player.app.R
+import io.clappr.player.base.*
+import io.clappr.player.components.Container
+import io.clappr.player.components.Core
+import io.clappr.player.plugin.container.UIContainerPlugin
+import io.clappr.player.plugin.core.UICorePlugin
+
+
+open class PlaybackStatusPlugin(container: Container) : UIContainerPlugin(container) {
+
+    companion object : NamedType {
+        override val name = "playbackStatus"
+    }
+
+    override val view by lazy {
+        LayoutInflater.from(context).inflate(R.layout.playback_status_plugin, null) as RelativeLayout
+    }
+
+    open val status by lazy { view.findViewById(R.id.status) as TextView }
+
+    private val playbackListenerIds = mutableListOf<String>()
+
+    init {
+        bindContainerEvents()
+    }
+
+    private fun bindContainerEvents() {
+        listenTo(container, InternalEvent.DID_CHANGE_PLAYBACK.value, Callback.wrap {
+            hide()
+            bindPlaybackEvents()
+        })
+    }
+
+    private fun bindPlaybackEvents() {
+        stopPlaybackListeners()
+
+        container.playback?.let {
+            playbackListenerIds.add(listenTo(it, Event.STALLING.value, updateLabel("loading")))
+            playbackListenerIds.add(listenTo(it, Event.PLAYING.value, updateLabel("playing")))
+            playbackListenerIds.add(listenTo(it, Event.DID_PAUSE.value, updateLabel("paused")))
+            playbackListenerIds.add(listenTo(it, Event.DID_STOP.value, updateLabel("stopped")))
+            playbackListenerIds.add(listenTo(it, Event.DID_COMPLETE.value, updateLabel("completed")))
+            playbackListenerIds.add(listenTo(it, Event.ERROR.value, updateLabel("failed")))
+        }
+    }
+
+    private fun updateLabel(text: String): Callback {
+        return Callback.wrap {
+            status.text = text
+            show()
+        }
+    }
+
+    private fun stopPlaybackListeners() {
+        playbackListenerIds.forEach(::stopListening)
+        playbackListenerIds.clear()
+    }
+}

--- a/app/src/main/kotlin/io/clappr/player/app/plugin/PlaybackStatusPlugin.kt
+++ b/app/src/main/kotlin/io/clappr/player/app/plugin/PlaybackStatusPlugin.kt
@@ -1,20 +1,18 @@
 package io.clappr.player.app.plugin
 
 import android.view.LayoutInflater
-import android.widget.ImageView
-import android.widget.LinearLayout
 import android.widget.RelativeLayout
 import android.widget.TextView
-import com.squareup.picasso.Picasso
 import io.clappr.player.app.R
-import io.clappr.player.base.*
+import io.clappr.player.base.Callback
+import io.clappr.player.base.Event
+import io.clappr.player.base.InternalEvent
+import io.clappr.player.base.NamedType
 import io.clappr.player.components.Container
-import io.clappr.player.components.Core
 import io.clappr.player.plugin.container.UIContainerPlugin
-import io.clappr.player.plugin.core.UICorePlugin
 
 
-open class PlaybackStatusPlugin(container: Container) : UIContainerPlugin(container) {
+class PlaybackStatusPlugin(container: Container) : UIContainerPlugin(container) {
 
     companion object : NamedType {
         override val name = "playbackStatus"

--- a/app/src/main/kotlin/io/clappr/player/app/plugin/PlaybackStatusPlugin.kt
+++ b/app/src/main/kotlin/io/clappr/player/app/plugin/PlaybackStatusPlugin.kt
@@ -43,12 +43,12 @@ open class PlaybackStatusPlugin(container: Container) : UIContainerPlugin(contai
         stopPlaybackListeners()
 
         container.playback?.let {
-            playbackListenerIds.add(listenTo(it, Event.STALLING.value, updateLabel("loading")))
-            playbackListenerIds.add(listenTo(it, Event.PLAYING.value, updateLabel("playing")))
-            playbackListenerIds.add(listenTo(it, Event.DID_PAUSE.value, updateLabel("paused")))
-            playbackListenerIds.add(listenTo(it, Event.DID_STOP.value, updateLabel("stopped")))
-            playbackListenerIds.add(listenTo(it, Event.DID_COMPLETE.value, updateLabel("completed")))
-            playbackListenerIds.add(listenTo(it, Event.ERROR.value, updateLabel("failed")))
+            playbackListenerIds.add(listenTo(it, Event.STALLING.value, updateLabel(Event.STALLING.value)))
+            playbackListenerIds.add(listenTo(it, Event.PLAYING.value, updateLabel(Event.PLAYING.value)))
+            playbackListenerIds.add(listenTo(it, Event.DID_PAUSE.value, updateLabel(Event.DID_PAUSE.value)))
+            playbackListenerIds.add(listenTo(it, Event.DID_STOP.value, updateLabel(Event.DID_STOP.value)))
+            playbackListenerIds.add(listenTo(it, Event.DID_COMPLETE.value, updateLabel(Event.DID_COMPLETE.value)))
+            playbackListenerIds.add(listenTo(it, Event.ERROR.value, updateLabel(Event.ERROR.value)))
         }
     }
 

--- a/app/src/main/kotlin/io/clappr/player/app/plugin/PlaybackStatusPlugin.kt
+++ b/app/src/main/kotlin/io/clappr/player/app/plugin/PlaybackStatusPlugin.kt
@@ -24,7 +24,7 @@ open class PlaybackStatusPlugin(container: Container) : UIContainerPlugin(contai
         LayoutInflater.from(context).inflate(R.layout.playback_status_plugin, null) as RelativeLayout
     }
 
-    open val status by lazy { view.findViewById(R.id.status) as TextView }
+    private val status by lazy { view.findViewById(R.id.status) as TextView }
 
     private val playbackListenerIds = mutableListOf<String>()
 

--- a/app/src/main/kotlin/io/clappr/player/app/plugin/VideoInfoPlugin.kt
+++ b/app/src/main/kotlin/io/clappr/player/app/plugin/VideoInfoPlugin.kt
@@ -13,7 +13,7 @@ import io.clappr.player.base.NamedType
 import io.clappr.player.components.Core
 import io.clappr.player.plugin.control.MediaControl
 
-open class VideoInfoPlugin(core: Core) : MediaControl.Plugin(core) {
+class VideoInfoPlugin(core: Core) : MediaControl.Plugin(core) {
 
     enum class Option(val value: String) {
         TITLE("$name:title"),

--- a/app/src/main/res/layout/playback_status_plugin.xml
+++ b/app/src/main/res/layout/playback_status_plugin.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:orientation="horizontal"
     android:gravity="end"
     android:paddingHorizontal="@dimen/playback_status_plugin_panel_padding"
     android:layout_width="wrap_content"

--- a/app/src/main/res/layout/playback_status_plugin.xml
+++ b/app/src/main/res/layout/playback_status_plugin.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="horizontal"
+    android:gravity="end"
+    android:paddingHorizontal="@dimen/playback_status_plugin_panel_padding"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content">
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:textColor="@color/playback_status_plugin_text_color"
+        android:textSize="@dimen/playback_status_plugin_font_size"
+        android:text="@string/playback_status_label"
+        android:layout_toLeftOf="@id/status"
+        android:padding="@dimen/playback_status_plugin_text_padding"
+        android:lines="1"/>
+
+    <TextView
+        android:id="@+id/status"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:textColor="@color/playback_status_plugin_text_color"
+        android:textSize="@dimen/playback_status_plugin_font_size"
+        android:ellipsize="end"
+        android:padding="@dimen/playback_status_plugin_text_padding"
+        android:layout_alignParentRight="true"
+        android:lines="1"/>
+
+</RelativeLayout>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -2,4 +2,5 @@
 <resources>
     <color name="next_video_plugin_text_color">#FFF</color>
     <color name="next_video_plugin_border_color">#85969494</color>
+    <color name="playback_status_plugin_text_color">#FFF</color>
 </resources>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -18,4 +18,8 @@
     <dimen name="video_info_subtitle_font_size">14sp</dimen>
     <dimen name="video_info_subtitle_top_margin">6dp</dimen>
     <dimen name="video_info_title_right_margin">10dp</dimen>
+
+    <dimen name="playback_status_plugin_font_size">10sp</dimen>
+    <dimen name="playback_status_plugin_text_padding">1dp</dimen>
+    <dimen name="playback_status_plugin_panel_padding">3dp</dimen>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -10,4 +10,5 @@
     <string name="play_next_video">Play Next Video:</string>
     <string name="video_title">Video Title</string>
     <string name="video_subtitle">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</string>
+    <string name="playback_status_label">Playback Status:</string>
 </resources>

--- a/app/src/test/kotlin/io/clappr/player/app/plugin/PlaybackStatusPluginTest.kt
+++ b/app/src/test/kotlin/io/clappr/player/app/plugin/PlaybackStatusPluginTest.kt
@@ -1,0 +1,121 @@
+package io.clappr.player.app.plugin
+
+import android.app.Application
+import android.view.View
+import android.widget.TextView
+import io.clappr.player.BuildConfig
+import io.clappr.player.app.R
+import io.clappr.player.app.plugin.util.FakePlayback
+import io.clappr.player.app.plugin.util.assertHidden
+import io.clappr.player.app.plugin.util.assertShown
+import io.clappr.player.base.BaseObject
+import io.clappr.player.base.Event
+import io.clappr.player.base.Options
+import io.clappr.player.components.Container
+import io.clappr.player.components.Core
+import io.clappr.player.plugin.Loader
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.robolectric.shadows.ShadowApplication
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+
+@RunWith(RobolectricTestRunner::class)
+@Config(constants = BuildConfig::class, sdk = [23], application = Application::class)
+class PlaybackStatusPluginTest {
+
+    private lateinit var container: Container
+
+    private lateinit var playbackStatusPlugin: PlaybackStatusPlugin
+
+    private val source = "url"
+
+    @Before
+    fun setup() {
+        BaseObject.context = ShadowApplication.getInstance().applicationContext
+
+        container = Container(Loader(), Options(source = source))
+
+        playbackStatusPlugin = PlaybackStatusPlugin(container)
+
+        //Trigger Playback change events
+        container.playback = FakePlayback("")
+
+        playbackStatusPlugin.render()
+    }
+
+    @Test
+    fun shouldHideViewAfterDidChangePlaybackEventIsTriggered() {
+        val newPlayback = FakePlayback(source)
+        container.playback = newPlayback
+
+        assertHidden(playbackStatusPlugin)
+    }
+
+    @Test
+    fun shouldShowViewWhenStallingEventIsTriggered() {
+        assertLabelOnEvent(Event.STALLING.value)
+    }
+
+    @Test
+    fun shouldShowViewWhenDidPauseEventIsTriggered() {
+        assertLabelOnEvent(Event.DID_PAUSE.value)
+    }
+
+    @Test
+    fun shouldShowViewWheDidStopEventIsTriggered() {
+        assertLabelOnEvent(Event.DID_STOP.value)
+    }
+
+    @Test
+    fun shouldShowViewWhenDidCompleteEventIsTriggered() {
+        assertLabelOnEvent(Event.DID_COMPLETE.value)
+    }
+
+    @Test
+    fun shouldShowViewWhenErrorEventIsTriggered() {
+        assertLabelOnEvent(Event.ERROR.value)
+    }
+
+    @Test
+    fun shouldStopListeningOldPlaybackWhenDidChangePlaybackEventIsTriggered() {
+        val oldPlayback = container.playback
+
+        assertHidden(playbackStatusPlugin)
+
+        val newPlayback = FakePlayback(source)
+        container.playback = newPlayback
+
+        oldPlayback?.trigger(Event.WILL_PLAY.value)
+
+        assertHidden(playbackStatusPlugin)
+    }
+
+    @Test
+    fun shouldStopListeningOldPlaybackWhenPluginIsDestroyed() {
+        val oldPlayback = container.playback
+
+        playbackStatusPlugin.destroy()
+
+        oldPlayback?.trigger(Event.WILL_PLAY.value)
+
+        assertHidden(playbackStatusPlugin)
+    }
+
+    private fun assertLabelOnEvent(eventName: String) {
+        container.playback?.trigger(eventName)
+
+        assertText(eventName)
+        assertShown(playbackStatusPlugin)
+    }
+
+    private fun assertText(text: String) {
+        playbackStatusPlugin.view.findViewById<TextView>(R.id.status).let {
+            assertNotNull(it)
+            assertEquals(text, it.text.toString())
+        }
+    }
+}


### PR DESCRIPTION
Goal
---
Add external plugin to Player.

`PlaybackStatePlugin` is a `UIContainerPlugin` to show status of current playback
 
How to Test
---
- open clappr app
- while loading video, should show `Playback Status: stalling`
- while playing video, should show `Playback Status: playing`
- after pause video, should show `Playback Status: didPause`
- after stop video, should show `Playback Status: didStop`
- after complete video, should show `Playback Status: didComplete`
- after an error, should show `Playback Status: error`