### PR TITLE
Remove version information from library

### DIFF
--- a/clappr/build.gradle
+++ b/clappr/build.gradle
@@ -50,7 +50,6 @@ android {
     defaultConfig {
         minSdkVersion 14
         targetSdkVersion 27
-        versionCode publishAttrs['versionCode']
         versionName publishAttrs['versionName']
     }
     packagingOptions {

--- a/clappr/build.gradle
+++ b/clappr/build.gradle
@@ -50,7 +50,8 @@ android {
     defaultConfig {
         minSdkVersion 14
         targetSdkVersion 27
-        versionName publishAttrs['versionName']
+
+        buildConfigField("String", "CLAPPR_VERSION", "\"$version\"")
     }
     packagingOptions {
         // workaround for http://stackoverflow.com/questions/20673625/android-gradle-plugin-0-7-0-duplicate-files-during-packaging-of-apk

--- a/clappr/versioning.gradle
+++ b/clappr/versioning.gradle
@@ -21,15 +21,14 @@ ext {
     }
     buildPublishAttrs = { version ->
         def versionType = buildVersionType(version)
-        def versionName = version
 
         def bintrayRepoName = (versionType == SNAPSHOT)? 'clappr-android-snapshot' : 'clappr-android-release'
         def bintrayVersionDesc = (versionType == SNAPSHOT)? 'Clappr snapshot' : (versionType == RC)? 'Clappr candidate alpha version': 'Clappr alpha version'
         def bintrayPublishNonDefault = (versionType == RELEASE)? false : true
-        println "Building $bintrayVersionDesc ($versionName) as $versionType to publish on $bintrayRepoName"
+        println "Building $bintrayVersionDesc ($version) as $versionType to publish on $bintrayRepoName"
 
         [
-                versionName: versionName,
+                versionName: version,
                 versionType: versionType,
                 bintrayRepoName: bintrayRepoName,
                 bintrayVersionDesc: bintrayVersionDesc,

--- a/clappr/versioning.gradle
+++ b/clappr/versioning.gradle
@@ -6,14 +6,6 @@ ext {
     def RELEASE = "RELEASE"
     def SNAPSHOT = "SNAPSHOT"
 
-    buildVersionCode = { version ->
-        def (major, minor, patch) = version.toLowerCase().tokenize('.')
-        patch = patch.tokenize('-').first()
-
-        (major, minor, patch) = [major, minor, patch].collect{it.toInteger()}
-
-        (major * 1000000) + (minor * 1000) + patch;
-    }
     buildVersionType = { version ->
         if (version.toUpperCase().contains("SNAPSHOT")) {
             throw new Exception("Reserved word \"SNAPSHOT\" can not be used in the version name")
@@ -30,15 +22,13 @@ ext {
     buildPublishAttrs = { version ->
         def versionType = buildVersionType(version)
         def versionName = version
-        def versionCode = buildVersionCode(version)
 
         def bintrayRepoName = (versionType == SNAPSHOT)? 'clappr-android-snapshot' : 'clappr-android-release'
         def bintrayVersionDesc = (versionType == SNAPSHOT)? 'Clappr snapshot' : (versionType == RC)? 'Clappr candidate alpha version': 'Clappr alpha version'
         def bintrayPublishNonDefault = (versionType == RELEASE)? false : true
-        println "Building $bintrayVersionDesc ($versionCode - $versionName) as $versionType to publish on $bintrayRepoName"
+        println "Building $bintrayVersionDesc ($versionName) as $versionType to publish on $bintrayRepoName"
 
         [
-                versionCode: versionCode,
                 versionName: versionName,
                 versionType: versionType,
                 bintrayRepoName: bintrayRepoName,


### PR DESCRIPTION
Android `versionName` and `versionCode` are not required in the `AndroidManifest` of an .aar library.