### PR TITLE
Make sure show NextVideoPlugin above another UiCorePlugins

### DIFF
--- a/app/src/main/kotlin/io/clappr/player/app/plugin/NextVideoPlugin.kt
+++ b/app/src/main/kotlin/io/clappr/player/app/plugin/NextVideoPlugin.kt
@@ -80,6 +80,7 @@ class NextVideoPlugin(core: Core) : UICorePlugin(core) {
 
     private fun showNextVideo() = Callback.wrap {
         show()
+        view.bringToFront()
     }
 
     private fun stopPlaybackListeners() {

--- a/app/src/main/kotlin/io/clappr/player/app/plugin/NextVideoPlugin.kt
+++ b/app/src/main/kotlin/io/clappr/player/app/plugin/NextVideoPlugin.kt
@@ -79,8 +79,8 @@ class NextVideoPlugin(core: Core) : UICorePlugin(core) {
     }
 
     private fun showNextVideo() = Callback.wrap {
-        show()
         view.bringToFront()
+        show()
     }
 
     private fun stopPlaybackListeners() {

--- a/app/src/test/kotlin/io/clappr/player/app/plugin/NextVideoPluginTest.kt
+++ b/app/src/test/kotlin/io/clappr/player/app/plugin/NextVideoPluginTest.kt
@@ -7,8 +7,8 @@ import android.widget.LinearLayout
 import io.clappr.player.BuildConfig
 import io.clappr.player.app.R
 import io.clappr.player.app.plugin.util.FakePlayback
-import io.clappr.player.app.plugin.util.assertHidden
-import io.clappr.player.app.plugin.util.assertShown
+import io.clappr.player.app.plugin.assertPlugin.assertUiPluginHidden
+import io.clappr.player.app.plugin.assertPlugin.assertUiPluginShown
 import io.clappr.player.base.BaseObject
 import io.clappr.player.base.Event
 import io.clappr.player.base.NamedType
@@ -64,7 +64,7 @@ class NextVideoPluginTest {
 
     @Test
     fun shouldHideAfterDidChangePlaybackEventIsTriggered() {
-        assertHidden(nextVideoPlugin)
+        assertUiPluginHidden(nextVideoPlugin)
     }
 
     @Test
@@ -73,14 +73,14 @@ class NextVideoPluginTest {
 
         core.activeContainer?.playback?.trigger(Event.WILL_PLAY.value)
 
-        assertHidden(nextVideoPlugin)
+        assertUiPluginHidden(nextVideoPlugin)
     }
 
     @Test
     fun shouldShowViewWhenDidCompleteEventIsTriggered() {
         core.activeContainer?.playback?.trigger(Event.DID_COMPLETE.value)
 
-        assertShown(nextVideoPlugin)
+        assertUiPluginShown(nextVideoPlugin)
     }
 
     @Test
@@ -96,7 +96,7 @@ class NextVideoPluginTest {
     fun shouldShowViewWhenDidStopEventIsTriggered() {
         core.activeContainer?.playback?.trigger(Event.DID_STOP.value)
 
-        assertShown(nextVideoPlugin)
+        assertUiPluginShown(nextVideoPlugin)
     }
 
     @Test
@@ -106,7 +106,7 @@ class NextVideoPluginTest {
         val newPlayback = FakePlayback(source)
         core.activeContainer?.playback = newPlayback
 
-        assertHidden(nextVideoPlugin)
+        assertUiPluginHidden(nextVideoPlugin)
     }
 
     @Test

--- a/app/src/test/kotlin/io/clappr/player/app/plugin/PlaybackStatusPluginTest.kt
+++ b/app/src/test/kotlin/io/clappr/player/app/plugin/PlaybackStatusPluginTest.kt
@@ -1,18 +1,16 @@
 package io.clappr.player.app.plugin
 
 import android.app.Application
-import android.view.View
 import android.widget.TextView
 import io.clappr.player.BuildConfig
 import io.clappr.player.app.R
 import io.clappr.player.app.plugin.util.FakePlayback
-import io.clappr.player.app.plugin.util.assertHidden
-import io.clappr.player.app.plugin.util.assertShown
+import io.clappr.player.app.plugin.assertPlugin.assertUiPluginHidden
+import io.clappr.player.app.plugin.assertPlugin.assertUiPluginShown
 import io.clappr.player.base.BaseObject
 import io.clappr.player.base.Event
 import io.clappr.player.base.Options
 import io.clappr.player.components.Container
-import io.clappr.player.components.Core
 import io.clappr.player.plugin.Loader
 import org.junit.Before
 import org.junit.Test
@@ -52,7 +50,7 @@ class PlaybackStatusPluginTest {
         val newPlayback = FakePlayback(source)
         container.playback = newPlayback
 
-        assertHidden(playbackStatusPlugin)
+        assertUiPluginHidden(playbackStatusPlugin)
     }
 
     @Test
@@ -84,14 +82,14 @@ class PlaybackStatusPluginTest {
     fun shouldStopListeningOldPlaybackWhenDidChangePlaybackEventIsTriggered() {
         val oldPlayback = container.playback
 
-        assertHidden(playbackStatusPlugin)
+        assertUiPluginHidden(playbackStatusPlugin)
 
         val newPlayback = FakePlayback(source)
         container.playback = newPlayback
 
         oldPlayback?.trigger(Event.WILL_PLAY.value)
 
-        assertHidden(playbackStatusPlugin)
+        assertUiPluginHidden(playbackStatusPlugin)
     }
 
     @Test
@@ -102,14 +100,14 @@ class PlaybackStatusPluginTest {
 
         oldPlayback?.trigger(Event.WILL_PLAY.value)
 
-        assertHidden(playbackStatusPlugin)
+        assertUiPluginHidden(playbackStatusPlugin)
     }
 
     private fun assertLabelOnEvent(eventName: String) {
         container.playback?.trigger(eventName)
 
         assertText(eventName)
-        assertShown(playbackStatusPlugin)
+        assertUiPluginShown(playbackStatusPlugin)
     }
 
     private fun assertText(text: String) {

--- a/app/src/test/kotlin/io/clappr/player/app/plugin/VideoInfoPluginTest.kt
+++ b/app/src/test/kotlin/io/clappr/player/app/plugin/VideoInfoPluginTest.kt
@@ -6,8 +6,8 @@ import android.widget.TextView
 import io.clappr.player.BuildConfig
 import io.clappr.player.app.R
 import io.clappr.player.app.plugin.util.FakePlayback
-import io.clappr.player.app.plugin.util.assertHidden
-import io.clappr.player.app.plugin.util.assertShown
+import io.clappr.player.app.plugin.assertPlugin.assertUiPluginHidden
+import io.clappr.player.app.plugin.assertPlugin.assertUiPluginShown
 import io.clappr.player.base.BaseObject
 import io.clappr.player.base.Event
 import io.clappr.player.base.Options
@@ -101,28 +101,28 @@ class VideoInfoPluginTest {
         val newPlayback = FakePlayback(source)
         core.activeContainer?.playback = newPlayback
 
-        assertHidden(videoInfoPlugin)
+        assertUiPluginHidden(videoInfoPlugin)
     }
 
     @Test
     fun shouldShowViewWhenWillPlayEventIsTriggered() {
         core.activeContainer?.playback?.trigger(Event.WILL_PLAY.value)
 
-        assertShown(videoInfoPlugin)
+        assertUiPluginShown(videoInfoPlugin)
     }
 
     @Test
     fun shouldStopListeningOldPlaybackWhenDidChangePlaybackEventIsTriggered() {
         val oldPlayback = core.activePlayback
 
-        assertHidden(videoInfoPlugin)
+        assertUiPluginHidden(videoInfoPlugin)
 
         val newPlayback = FakePlayback(source)
         core.activeContainer?.playback = newPlayback
 
         oldPlayback?.trigger(Event.WILL_PLAY.value)
 
-        assertHidden(videoInfoPlugin)
+        assertUiPluginHidden(videoInfoPlugin)
     }
 
     @Test
@@ -133,6 +133,6 @@ class VideoInfoPluginTest {
 
         oldPlayback?.trigger(Event.WILL_PLAY.value)
 
-        assertHidden(videoInfoPlugin)
+        assertUiPluginHidden(videoInfoPlugin)
     }
 }

--- a/app/src/test/kotlin/io/clappr/player/app/plugin/assertPlugin/assertUiPlugin.kt
+++ b/app/src/test/kotlin/io/clappr/player/app/plugin/assertPlugin/assertUiPlugin.kt
@@ -1,15 +1,15 @@
-package io.clappr.player.app.plugin.util
+package io.clappr.player.app.plugin.assertPlugin
 
 import android.view.View
 import io.clappr.player.plugin.UIPlugin
 import kotlin.test.assertEquals
 
-fun assertHidden(plugin: UIPlugin) {
+fun assertUiPluginHidden(plugin: UIPlugin) {
     assertEquals(UIPlugin.Visibility.HIDDEN, plugin.visibility)
     assertEquals(View.GONE, plugin.view?.visibility)
 }
 
-fun assertShown(plugin: UIPlugin) {
+fun assertUiPluginShown(plugin: UIPlugin) {
     assertEquals(UIPlugin.Visibility.VISIBLE, plugin.visibility)
     assertEquals(View.VISIBLE, plugin.view?.visibility)
 }


### PR DESCRIPTION
Sometimes `NextVideoPlugin` is shown behind Media Control and is not touchable. This PR make sure that when  `NextVideoPlugin` is shown, it will be on top of `Core` views.

## How to test
- Play a video until it ends and make sure you can choose next video.