### PR TITLE
Fix crash on Jelly Bean	(API 16 an 17) phones

### DIFF
--- a/clappr/src/main/kotlin/io/clappr/player/playback/ExoPlayerPlayBack.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/playback/ExoPlayerPlayBack.kt
@@ -2,7 +2,6 @@ package io.clappr.player.playback
 
 import android.annotation.SuppressLint
 import android.graphics.Color
-import android.media.UnsupportedSchemeException
 import android.net.Uri
 import android.os.Bundle
 import android.os.Handler
@@ -333,7 +332,6 @@ open class ExoPlayerPlayback(source: String, mimeType: String? = null, options: 
                         drmLicenses?.let { setMode(DefaultDrmSessionManager.MODE_QUERY, it) }
                     }
         }
-        catch (schemeException: UnsupportedSchemeException) { handleError(schemeException) }
         catch (drmException: UnsupportedDrmException) { handleError(drmException) }
 
         return drmSessionManager


### PR DESCRIPTION
Removed an API 18 dependency from Exoplayer Playback code.

How to test:
1. Run the application on an API 16 or 17 emulator