### PR TITLE
Trigger Resize Event

### DIFF
--- a/clappr/build.gradle
+++ b/clappr/build.gradle
@@ -109,6 +109,7 @@ dependencies {
     testImplementation "org.robolectric:robolectric:3.8"
     testImplementation 'org.khronos:opengl-api:gl1.1-android-2.1_r1'
     testImplementation "org.jetbrains.kotlin:kotlin-test:$kotlin_version"
+    testImplementation "com.nhaarman:mockito-kotlin:1.5.0"
 }
 
 tasks.matching {it instanceof Test}.all {

--- a/clappr/src/main/kotlin/io/clappr/player/base/InternalEvents.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/base/InternalEvents.kt
@@ -33,5 +33,7 @@ enum class InternalEvent (val value: String) {
     WILL_SHOW_MEDIA_CONTROL("willShowMediaControl"),
     WILL_HIDE_MEDIA_CONTROL("willHideMediaControl"),
     DID_HIDE_MEDIA_CONTROL("didHideMediaControl"),
-    DID_SHOW_MEDIA_CONTROL("didShowMediaControl")
+    DID_SHOW_MEDIA_CONTROL("didShowMediaControl"),
+
+    DID_RESIZE("didResize")
 }

--- a/clappr/src/main/kotlin/io/clappr/player/components/Core.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/components/Core.kt
@@ -85,15 +85,10 @@ class Core(options: Options) : UIObject() {
 
     private val layoutChangeListener = View.OnLayoutChangeListener { _, left, top, right, bottom,
                                                                      oldLeft, oldTop, oldRight, oldBottom ->
-        val horizontal = right - left
-        val oldHorizontal = oldRight - oldLeft
+        val horizontalChange = (right - left) != (oldRight - oldLeft)
+        val verticalChange = (bottom - top) != (oldBottom - oldTop)
 
-        val vertical = bottom - top
-        val oldVertical = oldBottom - oldTop
-
-        if (horizontal != oldHorizontal || vertical != oldVertical) {
-            trigger(InternalEvent.DID_RESIZE.value)
-        }
+        if (horizontalChange || verticalChange) { trigger(InternalEvent.DID_RESIZE.value) }
     }
 
     init {

--- a/clappr/src/main/kotlin/io/clappr/player/components/Core.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/components/Core.kt
@@ -1,6 +1,7 @@
 package io.clappr.player.components
 
 import android.os.Bundle
+import android.view.View
 import android.widget.FrameLayout
 import io.clappr.player.base.InternalEvent
 import io.clappr.player.base.Options
@@ -82,6 +83,19 @@ class Core(options: Options) : UIObject() {
     override val viewClass: Class<*>
         get() = FrameLayout::class.java
 
+    private val layoutChangeListener = View.OnLayoutChangeListener { _, left, top, right, bottom,
+                                                                     oldLeft, oldTop, oldRight, oldBottom ->
+        val horizontal = right - left
+        val oldHorizontal = oldRight - oldLeft
+
+        val vertical = bottom - top
+        val oldVertical = oldBottom - oldTop
+
+        if (horizontal != oldHorizontal || vertical != oldVertical) {
+            trigger(InternalEvent.DID_RESIZE.value)
+        }
+    }
+
     init {
         internalPlugins = Loader.loadPlugins(this).toMutableList()
 
@@ -107,6 +121,7 @@ class Core(options: Options) : UIObject() {
         }
         internalPlugins.clear()
         stopListening()
+        frameLayout.removeOnLayoutChangeListener(layoutChangeListener)
         trigger(InternalEvent.DID_DESTROY.value)
     }
 
@@ -122,6 +137,10 @@ class Core(options: Options) : UIObject() {
                     { it.render() },
                     "Plugin ${it.javaClass.simpleName} crashed during render")
         }
+
+        frameLayout.removeOnLayoutChangeListener(layoutChangeListener)
+        frameLayout.addOnLayoutChangeListener(layoutChangeListener)
+
         return this
     }
 

--- a/clappr/src/test/kotlin/io/clappr/player/components/CoreTest.kt
+++ b/clappr/src/test/kotlin/io/clappr/player/components/CoreTest.kt
@@ -16,8 +16,7 @@ import org.junit.Assert.*
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mockito.ArgumentCaptor
-import org.mockito.Mockito
+import org.mockito.*
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 import org.robolectric.shadows.ShadowApplication
@@ -62,8 +61,16 @@ open class CoreTest {
         }
     }
 
+    @Mock
+    private lateinit var frameLayoutMock: FrameLayout
+
+    @Captor
+    private lateinit var onLayoutChangeListenerCapture: ArgumentCaptor<View.OnLayoutChangeListener>
+
     @Before
     fun setup() {
+        MockitoAnnotations.initMocks(this)
+
         BaseObject.applicationContext = ShadowApplication.getInstance().applicationContext
     }
 
@@ -301,136 +308,125 @@ open class CoreTest {
 
     @Test
     fun shouldRemoveLayoutChangeListenerOnDestroy() {
-        val mockView = Mockito.mock(FrameLayout::class.java)
-        val core = Core(options = Options(source = "source")).apply { view = mockView }
+        val core = Core(options = Options(source = "source")).apply { view = frameLayoutMock }
 
         core.destroy()
 
-        verify(mockView).removeOnLayoutChangeListener(any())
+        verify(frameLayoutMock).removeOnLayoutChangeListener(any())
     }
 
     @Test
     fun shouldAddLayoutChangeListenerOnRender() {
-        val mockView = Mockito.mock(FrameLayout::class.java)
-        val core = Core(options = Options(source = "source")).apply { view = mockView }
+        val core = Core(options = Options(source = "source")).apply { view = frameLayoutMock }
 
         core.render()
 
-        verify(mockView).addOnLayoutChangeListener(any())
+        verify(frameLayoutMock).addOnLayoutChangeListener(any())
     }
 
     @Test
     fun shouldRemoveBeforeAddLayoutChangeListenerOnRender() {
-        val mockView = Mockito.mock(FrameLayout::class.java)
-        val core = Core(options = Options(source = "source")).apply { view = mockView }
+        val core = Core(options = Options(source = "source")).apply { view = frameLayoutMock }
 
         core.render()
 
-        with(inOrder(mockView)) {
-            verify(mockView).removeOnLayoutChangeListener(any())
-            verify(mockView).addOnLayoutChangeListener(any())
+        with(inOrder(frameLayoutMock)) {
+            verify(frameLayoutMock).removeOnLayoutChangeListener(any())
+            verify(frameLayoutMock).addOnLayoutChangeListener(any())
         }
     }
 
     @Test
     fun shouldRemoveAndAddTheSameLayoutChangeListenerOnRender() {
-        val mockView = Mockito.mock(FrameLayout::class.java)
-        val listenerCapture = ArgumentCaptor.forClass(View.OnLayoutChangeListener::class.java)
-        val core = Core(options = Options(source = "source")).apply { view = mockView }
+        val core = Core(options = Options(source = "source")).apply { view = frameLayoutMock }
 
         core.render()
 
-        verify(mockView).removeOnLayoutChangeListener(capture(listenerCapture))
-        verify(mockView).addOnLayoutChangeListener(listenerCapture.value)
+        verify(frameLayoutMock).removeOnLayoutChangeListener(capture(onLayoutChangeListenerCapture))
+        verify(frameLayoutMock).addOnLayoutChangeListener(onLayoutChangeListenerCapture.value)
     }
 
     @Test
     fun shouldRemoveTheSameLayoutChangeListenerOnDestroy() {
-        val mockView = Mockito.mock(FrameLayout::class.java)
-        val listenerCapture = ArgumentCaptor.forClass(View.OnLayoutChangeListener::class.java)
-        val core = Core(options = Options(source = "source")).apply { view = mockView }
+        val core = Core(options = Options(source = "source")).apply { view = frameLayoutMock }
 
         core.render()
-        verify(mockView).addOnLayoutChangeListener(capture(listenerCapture))
+        verify(frameLayoutMock).addOnLayoutChangeListener(capture(onLayoutChangeListenerCapture))
 
         core.destroy()
-        verify(mockView, times(2)).removeOnLayoutChangeListener(listenerCapture.value)
+        verify(frameLayoutMock, times(2))
+                .removeOnLayoutChangeListener(onLayoutChangeListenerCapture.value)
     }
 
     @Test
     fun shouldTriggerDidResizeWhenLayoutChangeSizeHorizontallyToRight() {
-        val mockView = Mockito.mock(FrameLayout::class.java)
-        val listenerCapture = ArgumentCaptor.forClass(View.OnLayoutChangeListener::class.java)
-        val (core, testPlugin) = setupTestCorePlugin().apply { first.view = mockView }
+        val (core, testPlugin) = setupTestCorePlugin().apply { first.view = frameLayoutMock }
 
         core.render()
-        verify(mockView).addOnLayoutChangeListener(capture(listenerCapture))
+        verify(frameLayoutMock).addOnLayoutChangeListener(capture(onLayoutChangeListenerCapture))
 
         val right = 1920
         val oldRight = 1080
-        listenerCapture.value.onLayoutChange(mockView, 0, 0, right, 0, 0, 0, oldRight, 0)
+        onLayoutChangeListenerCapture.value.onLayoutChange(
+                frameLayoutMock, 0, 0, right, 0, 0, 0, oldRight, 0)
 
         assertTrue(testPlugin.didResizeWasCalled)
     }
 
     @Test
     fun shouldTriggerDidResizeWhenLayoutChangeSizeHorizontallyToLeft() {
-        val mockView = Mockito.mock(FrameLayout::class.java)
-        val listenerCapture = ArgumentCaptor.forClass(View.OnLayoutChangeListener::class.java)
-        val (core, testPlugin) = setupTestCorePlugin().apply { first.view = mockView }
+        val (core, testPlugin) = setupTestCorePlugin().apply { first.view = frameLayoutMock }
 
         core.render()
-        verify(mockView).addOnLayoutChangeListener(capture(listenerCapture))
+        verify(frameLayoutMock).addOnLayoutChangeListener(capture(onLayoutChangeListenerCapture))
 
         val left = 1920
         val oldLeft = 1080
-        listenerCapture.value.onLayoutChange(mockView, left, 0, 0, 0, oldLeft, 0, 0, 0)
+        onLayoutChangeListenerCapture.value.onLayoutChange(
+                frameLayoutMock, left, 0, 0, 0, oldLeft, 0, 0, 0)
 
         assertTrue(testPlugin.didResizeWasCalled)
     }
 
     @Test
     fun shouldTriggerDidResizeWhenLayoutChangeSizeVerticallyToTop() {
-        val mockView = Mockito.mock(FrameLayout::class.java)
-        val listenerCapture = ArgumentCaptor.forClass(View.OnLayoutChangeListener::class.java)
-        val (core, testPlugin) = setupTestCorePlugin().apply { first.view = mockView }
+        val (core, testPlugin) = setupTestCorePlugin().apply { first.view = frameLayoutMock }
 
         core.render()
-        verify(mockView).addOnLayoutChangeListener(capture(listenerCapture))
+        verify(frameLayoutMock).addOnLayoutChangeListener(capture(onLayoutChangeListenerCapture))
 
         val top = 1920
         val oldTop = 1080
-        listenerCapture.value.onLayoutChange(mockView, 0, top, 0, 0, 0, oldTop, 0, 0)
+        onLayoutChangeListenerCapture.value.onLayoutChange(
+                frameLayoutMock, 0, top, 0, 0, 0, oldTop, 0, 0)
 
         assertTrue(testPlugin.didResizeWasCalled)
     }
 
     @Test
     fun shouldTriggerDidResizeWhenLayoutChangeSizeVerticallyToBottom() {
-        val mockView = Mockito.mock(FrameLayout::class.java)
-        val listenerCapture = ArgumentCaptor.forClass(View.OnLayoutChangeListener::class.java)
-        val (core, testPlugin) = setupTestCorePlugin().apply { first.view = mockView }
+        val (core, testPlugin) = setupTestCorePlugin().apply { first.view = frameLayoutMock }
 
         core.render()
-        verify(mockView).addOnLayoutChangeListener(capture(listenerCapture))
+        verify(frameLayoutMock).addOnLayoutChangeListener(capture(onLayoutChangeListenerCapture))
 
         val bottom = 1920
         val oldBottom = 1080
-        listenerCapture.value.onLayoutChange(mockView, 0, 0, 0, bottom, 0, 0, 0, oldBottom)
+        onLayoutChangeListenerCapture.value.onLayoutChange(
+                frameLayoutMock, 0, 0, 0, bottom, 0, 0, 0, oldBottom)
 
         assertTrue(testPlugin.didResizeWasCalled)
     }
 
     @Test
     fun shouldNotTriggerDidResizeWhenLayoutNotChangeSize() {
-        val mockView = Mockito.mock(FrameLayout::class.java)
-        val listenerCapture = ArgumentCaptor.forClass(View.OnLayoutChangeListener::class.java)
-        val (core, testPlugin) = setupTestCorePlugin().apply { first.view = mockView }
+        val (core, testPlugin) = setupTestCorePlugin().apply { first.view = frameLayoutMock }
 
         core.render()
-        verify(mockView).addOnLayoutChangeListener(capture(listenerCapture))
+        verify(frameLayoutMock).addOnLayoutChangeListener(capture(onLayoutChangeListenerCapture))
 
-        listenerCapture.value.onLayoutChange(mockView, 100, 100, 100, 100, 100, 100, 100, 100)
+        onLayoutChangeListenerCapture.value.onLayoutChange(
+                frameLayoutMock, 100, 100, 100, 100, 100, 100, 100, 100)
 
         assertFalse(testPlugin.didResizeWasCalled)
     }


### PR DESCRIPTION
## Goal 

Trigger resize event when core view change size.

## How to test

- Run tests on `clappr` module

### Manual Test Setup

To test this feature add this plugin to the PlayerActivity in the sample app:

```kotlin
    class ResizePlugin(core: Core) : CorePlugin(core, name=name) {
        companion object : NamedType {
            override val name = "resizePlugin"
            val entry = PluginEntry.Core(name = name, factory = { core -> ResizePlugin(core) })
        }

        init { listenTo(core, InternalEvent.DID_RESIZE.value) { Log.d(name, "Did Resize was called") } }
    }
```

Then register the plugin before the Player instantiation in the onCreate method:

```kotlin
    Loader.register(ResizePlugin.entry)
    player = Player()
```

### Manual Test

- Open sample app
- Filter the log by `resizePlugin`
- You should see the message `Did Resize was called` the first time the Player is render
- Click in the fullscreen button or turn your phone
- You should see the message `Did Resize was called` every time the Core View change size