### PR TITLE
Fix: Playback media options

### DIFF
--- a/clappr/src/main/kotlin/io/clappr/player/Player.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/Player.kt
@@ -247,7 +247,7 @@ open class Player(private val base: BaseObject = BaseObject(),
 
     private fun bindPlaybackEvents() {
         core?.activePlayback?.let {
-            playbackEventsToListen.mapTo(playbackEventsIds) { event -> listenTo(it, event, { bundle: Bundle? -> trigger(event, bundle) }) }
+            playbackEventsToListen.mapTo(playbackEventsIds) { event -> listenTo(it, event) { bundle: Bundle? -> trigger(event, bundle) } }
         }
     }
 
@@ -260,7 +260,7 @@ open class Player(private val base: BaseObject = BaseObject(),
 
     private fun bindContainerEvents() {
         core?.activeContainer?.let {
-            containerEventsToListen.mapTo(containerEventsIds) { event -> listenTo(it, event, { bundle: Bundle? -> trigger(event, bundle) }) }
+            containerEventsToListen.mapTo(containerEventsIds) { event -> listenTo(it, event) { bundle: Bundle? -> trigger(event, bundle) } }
         }
     }
 

--- a/clappr/src/main/kotlin/io/clappr/player/base/Events.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/base/Events.kt
@@ -99,9 +99,15 @@ enum class Event(val value: String) {
     DID_UPDATE_POSTER("didUpdatePoster"),
 
     /**
-     * Media Options Selected. Data provided with the [EventData.MEDIA_OPTIONS_SELECTED_RESPONSE] key.
+     * Media Options Selected. Triggered when the user select a Media Option.
+     * Data provided with the [EventData.MEDIA_OPTIONS_SELECTED_RESPONSE] key.
      */
     MEDIA_OPTIONS_SELECTED("mediaOptionsSelected"),
+
+    /**
+     * Media Options Update. Triggered when the Playback load a media option
+     */
+    MEDIA_OPTIONS_UPDATE("mediaOptionsUpdate"),
 
     /**
      * There was a change in DVR status

--- a/clappr/src/main/kotlin/io/clappr/player/base/InternalEvents.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/base/InternalEvents.kt
@@ -17,7 +17,6 @@ enum class InternalEvent (val value: String) {
     WILL_DESTROY("willDestroy"),
     DID_DESTROY("didDestroy"),
     MEDIA_OPTIONS_READY("mediaOptionsReady"),
-    MEDIA_OPTIONS_UPDATE("mediaOptionsUpdate"),
     DID_UPDATE_OPTIONS("didUpdateOptions"),
 
     DID_TOUCH_MEDIA_CONTROL("didTouchMediaControl"),

--- a/clappr/src/main/kotlin/io/clappr/player/components/Playback.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/components/Playback.kt
@@ -1,9 +1,7 @@
 package io.clappr.player.components
 
-import android.os.Bundle
 import io.clappr.player.base.*
 import io.clappr.player.log.Logger
-import org.json.JSONArray
 import org.json.JSONException
 import org.json.JSONObject
 import java.util.*
@@ -129,11 +127,14 @@ abstract class Playback(
     }
 
     protected var mediaOptionList = LinkedList<MediaOption>()
-    protected var selectedMediaOptionList = ArrayList<MediaOption>()
+    var selectedMediaOptionList = ArrayList<MediaOption>()
+        private set
 
-    private val mediaOptionsArrayJson = "media_option"
-    private val mediaOptionsNameJson = "name"
-    private val mediaOptionsTypeJson = "type"
+    companion object {
+        const val mediaOptionsArrayJson = "media_option"
+        const val mediaOptionsNameJson = "name"
+        const val mediaOptionsTypeJson = "type"
+    }
 
     fun addAvailableMediaOption(media: MediaOption, index: Int = mediaOptionList.size) {
         mediaOptionList.add(index, media)
@@ -171,23 +172,6 @@ abstract class Playback(
         selectedMediaOptionList.add(mediaOption)
 
         trigger(InternalEvent.MEDIA_OPTIONS_UPDATE.value)
-
-        val bundle = Bundle()
-        bundle.putString(EventData.MEDIA_OPTIONS_SELECTED_RESPONSE.value, convertSelectedMediaOptionsToJson())
-        trigger(Event.MEDIA_OPTIONS_SELECTED.value, bundle)
-    }
-
-    private fun convertSelectedMediaOptionsToJson(): String {
-        val result = JSONObject()
-        val jsonArray = JSONArray()
-        selectedMediaOptionList.forEach {
-            val jsonObject = JSONObject()
-            jsonObject.put(mediaOptionsNameJson, it.name)
-            jsonObject.put(mediaOptionsTypeJson, it.type)
-            jsonArray.put(jsonObject)
-        }
-        result.put(mediaOptionsArrayJson, jsonArray)
-        return result.toString()
     }
 
     fun setupInitialMediasFromClapprOptions() {

--- a/clappr/src/main/kotlin/io/clappr/player/components/Playback.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/components/Playback.kt
@@ -171,7 +171,7 @@ abstract class Playback(
         selectedMediaOptionList.removeAll { it.type == mediaOption.type }
         selectedMediaOptionList.add(mediaOption)
 
-        trigger(InternalEvent.MEDIA_OPTIONS_UPDATE.value)
+        trigger(Event.MEDIA_OPTIONS_UPDATE.value)
     }
 
     fun setupInitialMediasFromClapprOptions() {

--- a/clappr/src/test/kotlin/io/clappr/player/PlayerTest.kt
+++ b/clappr/src/test/kotlin/io/clappr/player/PlayerTest.kt
@@ -416,8 +416,8 @@ open class PlayerTest {
 
         player = Player(playbackEventsToListen = mutableSetOf(playerTestEvent))
 
-        player.on(event) {
-            eventWasCalled = true
+        player.on(event) { bundle ->
+            eventWasCalled = bundle?.getBoolean(EventTestPlayback.eventBundle) ?: false
         }
 
         player.configure(Options(source = "valid"))
@@ -438,11 +438,17 @@ open class PlayerTest {
                     supportsSource = EventTestPlayback.supportsSource,
                     factory = { source, mimeType, options -> EventTestPlayback(source, mimeType, options) })
 
+            const val eventBundle = "test-bundle"
             var event: String? = null
         }
 
         override fun play(): Boolean {
-            EventTestPlayback.event?.let { trigger(it) }
+            EventTestPlayback.event?.let {
+                Bundle().apply {
+                    putBoolean(eventBundle, true)
+                    trigger(it, this)
+                }
+            }
             return super.play()
         }
     }

--- a/clappr/src/test/kotlin/io/clappr/player/PlayerTest.kt
+++ b/clappr/src/test/kotlin/io/clappr/player/PlayerTest.kt
@@ -38,6 +38,7 @@ open class PlayerTest {
         Loader.register(PlayerTestPlayback.entry)
 
         PlayerTestPlayback.internalState = Playback.State.NONE
+        EventTestPlayback.event = null
 
         player = Player(playbackEventsToListen = mutableSetOf(playerTestEvent))
     }
@@ -310,6 +311,140 @@ open class PlayerTest {
         player.play()
 
         assertEquals(expectedDistinctCoreId, coreIdList.size)
+    }
+
+    @Test
+    fun shouldListenReadyEventOutOfPlayer() {
+        assertEventWasTriggered(Event.READY.value)
+    }
+
+    @Test
+    fun shouldListenErrorEventOutOfPlayer() {
+        assertEventWasTriggered(Event.ERROR.value)
+    }
+
+    @Test
+    fun shouldListenPlayingEventOutOfPlayer() {
+        assertEventWasTriggered(Event.PLAYING.value)
+    }
+
+    @Test
+    fun shouldListenDidCompleteEventOutOfPlayer() {
+        assertEventWasTriggered(Event.DID_COMPLETE.value)
+    }
+
+    @Test
+    fun shouldListenDidPauseEventOutOfPlayer() {
+        assertEventWasTriggered(Event.DID_PAUSE.value)
+    }
+
+    @Test
+    fun shouldListenStallingEventOutOfPlayer() {
+        assertEventWasTriggered(Event.STALLING.value)
+    }
+
+    @Test
+    fun shouldListenDidStopEventOutOfPlayer() {
+        assertEventWasTriggered(Event.DID_STOP.value)
+    }
+
+    @Test
+    fun shouldListenDidSeekEventOutOfPlayer() {
+        assertEventWasTriggered(Event.DID_SEEK.value)
+    }
+
+    @Test
+    fun shouldListenDidUpdateBufferEventOutOfPlayer() {
+        assertEventWasTriggered(Event.DID_UPDATE_BUFFER.value)
+    }
+
+    @Test
+    fun shouldListenDidUpdatePositionEventOutOfPlayer() {
+        assertEventWasTriggered(Event.DID_UPDATE_POSITION.value)
+    }
+
+    @Test
+    fun shouldListenWillPlayEventOutOfPlayer() {
+        assertEventWasTriggered(Event.WILL_PLAY.value)
+    }
+
+    @Test
+    fun shouldListenWillPauseEventOutOfPlayer() {
+        assertEventWasTriggered(Event.WILL_PAUSE.value)
+    }
+
+    @Test
+    fun shouldListenWillSeekEventOutOfPlayer() {
+        assertEventWasTriggered(Event.WILL_SEEK.value)
+    }
+
+    @Test
+    fun shouldListenWillStopEventOutOfPlayer() {
+        assertEventWasTriggered(Event.WILL_STOP.value)
+    }
+
+    @Test
+    fun shouldListenDidChangeDVRStatusEventOutOfPlayer() {
+        assertEventWasTriggered(Event.DID_CHANGE_DVR_STATUS.value)
+    }
+
+    @Test
+    fun shouldListenDidChangeDVRAvailabilityEventOutOfPlayer() {
+        assertEventWasTriggered(Event.DID_CHANGE_DVR_AVAILABILITY.value)
+    }
+
+    @Test
+    fun shouldListenDidUpdateBitrateEventOutOfPlayer() {
+        assertEventWasTriggered(Event.DID_UPDATE_BITRATE.value)
+    }
+
+    @Test
+    fun shouldListenMediaOptionSelectedEventOutOfPlayer() {
+        assertEventWasTriggered(Event.MEDIA_OPTIONS_SELECTED.value)
+    }
+
+    @Test
+    fun shouldListenMediaOptionUpdateEventOutOfPlayer() {
+        assertEventWasTriggered(Event.MEDIA_OPTIONS_UPDATE.value)
+    }
+
+    private fun assertEventWasTriggered(event: String){
+        var eventWasCalled = false
+        Loader.register(EventTestPlayback.entry)
+
+        EventTestPlayback.event = event
+
+        player = Player(playbackEventsToListen = mutableSetOf(playerTestEvent))
+
+        player.on(event) {
+            eventWasCalled = true
+        }
+
+        player.configure(Options(source = "valid"))
+        player.play()
+
+        assertTrue(eventWasCalled)
+    }
+
+    class EventTestPlayback(source: String, mimeType: String? = null, options: Options = Options()):
+            Playback(source, mimeType, options, name = name, supportsSource = supportsSource) {
+
+        companion object {
+            const val name: String = "player_test"
+            val supportsSource: PlaybackSupportCheck = { source, _ -> source.isNotEmpty() }
+
+            val entry = PlaybackEntry(
+                    name = EventTestPlayback.name,
+                    supportsSource = EventTestPlayback.supportsSource,
+                    factory = { source, mimeType, options -> EventTestPlayback(source, mimeType, options) })
+
+            var event: String? = null
+        }
+
+        override fun play(): Boolean {
+            EventTestPlayback.event?.let { trigger(it) }
+            return super.play()
+        }
     }
 
     class PlayerTestPlayback(source: String, mimeType: String? = null, options: Options = Options()) :

--- a/clappr/src/test/kotlin/io/clappr/player/components/PlaybackTest.kt
+++ b/clappr/src/test/kotlin/io/clappr/player/components/PlaybackTest.kt
@@ -415,4 +415,19 @@ open class PlaybackTest {
         val playback = SomePlayback("valid-source.mp4", Options())
         assertFalse(playback.seekToLivePosition())
     }
+
+    @Test
+    fun shouldNotSentMediaOptionSelectedWhenOptionIsUpdated() {
+        var didSelectedMediaOption = false
+        val playback = SomePlayback("valid-source.mp4", Options())
+        val option = MediaOption(AudioLanguage.ORIGINAL.value, MediaOptionType.AUDIO, null, null)
+
+        playback.on(Event.MEDIA_OPTIONS_SELECTED.value) {
+            didSelectedMediaOption = true
+        }
+
+        playback.setSelectedMediaOption(option)
+
+        assertFalse(didSelectedMediaOption)
+    }
 }

--- a/clappr/src/test/kotlin/io/clappr/player/components/PlaybackTest.kt
+++ b/clappr/src/test/kotlin/io/clappr/player/components/PlaybackTest.kt
@@ -251,7 +251,7 @@ open class PlaybackTest {
 
         var mediaOptionsUpdateCalled = false
 
-        listenObject.listenTo(playback, InternalEvent.MEDIA_OPTIONS_UPDATE.value) { mediaOptionsUpdateCalled = true }
+        listenObject.listenTo(playback, Event.MEDIA_OPTIONS_UPDATE.value) { mediaOptionsUpdateCalled = true }
 
         playback.setSelectedMediaOption(MediaOption("Name", MediaOptionType.SUBTITLE, "name", null))
 


### PR DESCRIPTION
### **Goal**
Fix remove some playback responsibility. The playback should trigger `MEDIA_OPTIONS_UPDATE` event only, after a media option update. 

### **How to test**
Run player unit tests: `./gradlew clean test`