### PR TITLE
Fix: Trigger seek events when seekToLivePosition is called

### DIFF
--- a/clappr/src/main/kotlin/io/clappr/player/playback/ExoPlayerPlayBack.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/playback/ExoPlayerPlayBack.kt
@@ -286,7 +286,6 @@ open class ExoPlayerPlayback(source: String, mimeType: String? = null, options: 
 
     override fun startAt(seconds: Int): Boolean {
         if (!canSeek) return false
-
         player?.seekTo((seconds * ONE_SECOND_IN_MILLIS).toLong())
         triggerPositionUpdateEvent()
 
@@ -296,7 +295,10 @@ open class ExoPlayerPlayback(source: String, mimeType: String? = null, options: 
     override fun seekToLivePosition(): Boolean {
         if (!canSeek) return false
 
+        trigger(Event.WILL_SEEK)
         player?.seekToDefaultPosition()
+        trigger(Event.DID_SEEK)
+        triggerPositionUpdateEvent()
         return true
     }
 

--- a/clappr/src/test/kotlin/io/clappr/player/playback/ExoPlayerPlayBackTest.kt
+++ b/clappr/src/test/kotlin/io/clappr/player/playback/ExoPlayerPlayBackTest.kt
@@ -42,6 +42,36 @@ class ExoPlayerPlaybackTest {
     }
 
     @Test
+    fun shouldTriggerWillSeekWhenSeekToLivePositionIsCalled() {
+        var willSeekWasCalled = false
+        listenObject.listenTo(exoPlayerPlayBack, Event.WILL_SEEK.value) {
+            willSeekWasCalled = true
+        }
+        exoPlayerPlayBack.seekToLivePosition()
+        assertTrue("WILL_SEEK event wasn't triggered when seekToLivePosition() method was called", willSeekWasCalled)
+    }
+
+    @Test
+    fun shouldTriggerDidSeekWhenSeekToLivePositionIsCalled() {
+        var didSeekWasCalled = false
+        listenObject.listenTo(exoPlayerPlayBack, Event.DID_SEEK.value) {
+            didSeekWasCalled = true
+        }
+        exoPlayerPlayBack.seekToLivePosition()
+        assertTrue("DID_SEEK event wasn't triggered when seekToLivePosition() method was called", didSeekWasCalled)
+    }
+
+    @Test
+    fun shouldTriggerDidUpdatePositionWhenSeekToLivePositionIsCalled() {
+        var didUpdatePositionWasCalled = false
+        listenObject.listenTo(exoPlayerPlayBack, Event.DID_UPDATE_POSITION.value) { bundle ->
+            didUpdatePositionWasCalled = true
+        }
+        exoPlayerPlayBack.seekToLivePosition()
+        assertTrue("DID_UPDATE_POSITION event wasn't triggered when seekToLivePosition() method was called", didUpdatePositionWasCalled)
+    }
+
+    @Test
     fun shouldReturnZeroBitrateWhenHistoryIsEmpty() {
         assertEquals(0, exoPlayerPlayBack.bitrate)
     }


### PR DESCRIPTION
### **Goal**
Whenever the method `seekToLivePosition()` of `ExoPlayerPlayback` is called the events `WILL_SEEK`, `DID_SEEK` and `DID_UPDATE_POSITION` must be triggered to notify all corresponding changes that will be executed on the player

### **How to test**
Run player unit tests: `./gradlew clean test`