### PR TITLE
Fix: Reset Media Control State

### DIFF
--- a/clappr/src/main/kotlin/io/clappr/player/plugin/control/MediaControl.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/plugin/control/MediaControl.kt
@@ -129,7 +129,10 @@ class MediaControl(core: Core) : UICorePlugin(core, name = name) {
         core.activeContainer?.let {
             containerListenerIds.add(listenTo(it, InternalEvent.ENABLE_MEDIA_CONTROL.value) { state = State.ENABLED })
             containerListenerIds.add(listenTo(it, InternalEvent.DISABLE_MEDIA_CONTROL.value) { state = State.DISABLED })
-            containerListenerIds.add(listenTo(it, InternalEvent.WILL_LOAD_SOURCE.value) { hide() })
+            containerListenerIds.add(listenTo(it, InternalEvent.WILL_LOAD_SOURCE.value) {
+                state = State.ENABLED
+                hide()
+            })
         }
     }
 

--- a/clappr/src/test/kotlin/io/clappr/player/plugin/control/MediaControlTest.kt
+++ b/clappr/src/test/kotlin/io/clappr/player/plugin/control/MediaControlTest.kt
@@ -453,6 +453,15 @@ class MediaControlTest {
         assertEventTriggeredWhenShowIsCalled(InternalEvent.DID_SHOW_MEDIA_CONTROL.value)
     }
 
+    @Test
+    fun shouldEnableMediaControlWhenWillLoadSourceIsTriggered() {
+        mediaControl.state = Plugin.State.DISABLED
+
+        container.trigger(InternalEvent.WILL_LOAD_SOURCE.value)
+
+        assertEquals(Plugin.State.ENABLED, mediaControl.state)
+    }
+
     private fun getCenterPanel() = mediaControl.view.findViewById<LinearLayout>(R.id.center_panel)
     private fun getBottomPanel() = mediaControl.view.findViewById<LinearLayout>(R.id.bottom_panel)
     private fun getBottomLeftPanel() = mediaControl.view.findViewById<LinearLayout>(R.id.bottom_left_panel)


### PR DESCRIPTION
### Goal

Reset Media Control state when a new source is loaded.

### How to Test

Run Unit Tests: `./gradlew clean test`

1 - Open sample app
2 - Play video and ensure Media Control is working as expected