### PR TITLE
Disable seek when video is complete

### DIFF
--- a/clappr/src/main/kotlin/io/clappr/player/playback/ExoPlayerPlayBack.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/playback/ExoPlayerPlayBack.kt
@@ -147,10 +147,13 @@ open class ExoPlayerPlayback(source: String, mimeType: String? = null, options: 
     override val canSeek: Boolean
         get() = currentState != State.ERROR &&
                 !isVideoCompleted &&
-                when (mediaType) {
-                    MediaType.LIVE -> isDvrAvailable
-                    else -> duration != 0.0
-                }
+                canSeekByMediaType
+
+    private val canSeekByMediaType: Boolean
+        get() = when (mediaType) {
+            MediaType.LIVE -> isDvrAvailable
+            else -> duration != 0.0
+        }
 
     override var volume: Float?
         get() = player?.volume

--- a/clappr/src/main/kotlin/io/clappr/player/playback/ExoPlayerPlayBack.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/playback/ExoPlayerPlayBack.kt
@@ -53,6 +53,8 @@ open class ExoPlayerPlayback(source: String, mimeType: String? = null, options: 
                 factory = { source, mimeType, options -> ExoPlayerPlayback(source, mimeType, options) })
     }
 
+    private var isVideoCompleted = false
+
     private val ONE_SECOND_IN_MILLIS: Int = 1000
     private val DEFAULT_MIN_DVR_SIZE = 60
     private val MIN_DVR_LIVE_DRIFT = 5
@@ -144,6 +146,7 @@ open class ExoPlayerPlayback(source: String, mimeType: String? = null, options: 
 
     override val canSeek: Boolean
         get() = currentState != State.ERROR &&
+                !isVideoCompleted &&
                 when (mediaType) {
                     MediaType.LIVE -> isDvrAvailable
                     else -> duration != 0.0
@@ -232,6 +235,7 @@ open class ExoPlayerPlayback(source: String, mimeType: String? = null, options: 
 
         trigger(Event.WILL_PLAY)
         player?.playWhenReady = true
+        isVideoCompleted = false
         return true
     }
 
@@ -467,6 +471,7 @@ open class ExoPlayerPlayback(source: String, mimeType: String? = null, options: 
     private fun handleExoplayerEndedState() {
         currentState = State.IDLE
         trigger(Event.DID_COMPLETE)
+        isVideoCompleted = true
         stop()
     }
 

--- a/clappr/src/main/kotlin/io/clappr/player/playback/ExoPlayerPlayBack.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/playback/ExoPlayerPlayBack.kt
@@ -251,6 +251,7 @@ open class ExoPlayerPlayback(source: String, mimeType: String? = null, options: 
         trigger(Event.WILL_STOP)
         player?.stop()
         release()
+        currentState = State.IDLE
         trigger(Event.DID_STOP)
         return true
     }


### PR DESCRIPTION
Actually it is possible `seek` in a video when it is complete, however, the seek is not done by Exoplayer. This behavior create several problems with plugins that use `canSeek` Playback propertie since Exoplayer return that it is possible to seek but it don't. This PR make `canSeek` property return false when video is compleater.