### PR TITLE
Fix/video loop event

### DIFF
--- a/clappr/src/main/kotlin/io/clappr/player/clocks/MonotonicClock.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/clocks/MonotonicClock.kt
@@ -1,0 +1,7 @@
+package io.clappr.player.clocks
+
+import android.os.SystemClock
+
+typealias MonotonicClock = () -> Long
+
+val ClapprSystemClock: MonotonicClock = { SystemClock.uptimeMillis() }

--- a/clappr/src/main/kotlin/io/clappr/player/clocks/MonotonicClock.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/clocks/MonotonicClock.kt
@@ -1,7 +1,0 @@
-package io.clappr.player.clocks
-
-import android.os.SystemClock
-
-typealias MonotonicClock = () -> Long
-
-val clapprMonotonicClock: MonotonicClock = { SystemClock.uptimeMillis() }

--- a/clappr/src/main/kotlin/io/clappr/player/clocks/MonotonicClock.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/clocks/MonotonicClock.kt
@@ -4,4 +4,4 @@ import android.os.SystemClock
 
 typealias MonotonicClock = () -> Long
 
-val ClapprSystemClock: MonotonicClock = { SystemClock.uptimeMillis() }
+val clapprMonotonicClock: MonotonicClock = { SystemClock.uptimeMillis() }

--- a/clappr/src/main/kotlin/io/clappr/player/playback/ExoPlayerPlayBack.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/playback/ExoPlayerPlayBack.kt
@@ -220,8 +220,10 @@ open class ExoPlayerPlayback(source: String, mimeType: String? = null, options: 
 
     private val isRepeatModeEnabled
         get() = player?.let {
-            it.repeatMode == Player.REPEAT_MODE_ONE && options.options.containsKey(ClapprOption.LOOP.value)
-    } ?: false
+            it.repeatMode == Player.REPEAT_MODE_ONE &&
+                    options.options.containsKey(ClapprOption.LOOP.value) &&
+                    mediaType == MediaType.VOD
+        } ?: false
 
     init {
         playerView.useController = false

--- a/clappr/src/main/kotlin/io/clappr/player/playback/ExoPlayerPlayBack.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/playback/ExoPlayerPlayBack.kt
@@ -218,6 +218,11 @@ open class ExoPlayerPlayback(source: String, mimeType: String? = null, options: 
     override val currentTime: Long?
         get() = currentDate?.plus(position.toLong())
 
+    private val isRepeatModeEnabled
+        get() = player?.let {
+            it.repeatMode == Player.REPEAT_MODE_ONE && options.options.containsKey(ClapprOption.LOOP.value)
+    } ?: false
+
     init {
         playerView.useController = false
         playerView.subtitleView?.setStyle(getSubtitleStyle())
@@ -341,7 +346,7 @@ open class ExoPlayerPlayback(source: String, mimeType: String? = null, options: 
         player = ExoPlayerFactory.newSimpleInstance(rendererFactory, trackSelector)
         player?.playWhenReady = false
         player?.repeatMode = when (options.options[ClapprOption.LOOP.value]) {
-            true -> Player.REPEAT_MODE_ALL
+            true -> Player.REPEAT_MODE_ONE
             else -> Player.REPEAT_MODE_OFF
         }
 
@@ -694,7 +699,7 @@ open class ExoPlayerPlayback(source: String, mimeType: String? = null, options: 
         }
 
         override fun onPositionDiscontinuity(reason: Int) {
-            if (reason == Player.DISCONTINUITY_REASON_PERIOD_TRANSITION) {
+            if (isRepeatModeEnabled && reason == Player.DISCONTINUITY_REASON_PERIOD_TRANSITION) {
                 trigger(Event.DID_LOOP)
             }
         }

--- a/clappr/src/test/kotlin/io/clappr/player/playback/ExoPlayerPlayBackTest.kt
+++ b/clappr/src/test/kotlin/io/clappr/player/playback/ExoPlayerPlayBackTest.kt
@@ -273,7 +273,7 @@ class ExoPlayerPlaybackTest {
         exoPlayerPlayBack = ExoPlayerPlayback(source = source, options = options)
         exoPlayerPlayBack.load(source = source)
 
-        assertEquals(Player.REPEAT_MODE_ALL, SimpleExoplayerShadow.staticRepeatMode)
+        assertEquals(Player.REPEAT_MODE_ONE, SimpleExoplayerShadow.staticRepeatMode)
     }
 
     private fun addBitrateMediaLoadData(bitrate: Long, trackType: Int = C.TRACK_TYPE_DEFAULT): MediaSourceEventListener.MediaLoadData {


### PR DESCRIPTION
Trigger `DID_LOOP` event only for VOD videos and use `REPEATE_MODE_ONE` mode instdead `REPEATE_MODE_ALL` to make sure that just one period will be repeted. 
Also create a monotonic clock to be used in Clappr. This clock remove user clock change interference.