### PR TITLE
Audio Focus

### DIFF
--- a/clappr/src/main/kotlin/io/clappr/player/base/Options.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/base/Options.kt
@@ -45,5 +45,9 @@ enum class ClapprOption(val value: String) {
      *  If true the video will be played forever (loop mode).
      *  If false the video will be stopped when it ends
      */
-    LOOP("loop")
+    LOOP("loop"),
+    /**
+     * Boolean value indicating if Audio Focus should be handled by Clappr. Default value is false.
+     */
+    HANDLE_AUDIO_FOCUS("handleAudioFocus")
 }

--- a/clappr/src/main/kotlin/io/clappr/player/playback/ExoPlayerPlayBack.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/playback/ExoPlayerPlayBack.kt
@@ -8,6 +8,7 @@ import android.os.Handler
 import android.view.View
 import com.google.android.exoplayer2.*
 import com.google.android.exoplayer2.analytics.AnalyticsListener
+import com.google.android.exoplayer2.audio.AudioAttributes
 import com.google.android.exoplayer2.drm.*
 import com.google.android.exoplayer2.source.*
 import com.google.android.exoplayer2.source.dash.DashMediaSource
@@ -345,7 +346,14 @@ open class ExoPlayerPlayback(source: String, mimeType: String? = null, options: 
 
         configureTrackSelector()
 
-        player = ExoPlayerFactory.newSimpleInstance(rendererFactory, trackSelector)
+        val audioAttributes = AudioAttributes.Builder()
+            .setContentType(C.CONTENT_TYPE_MOVIE)
+                .setUsage(C.USAGE_MEDIA)
+                .build()
+
+        player = ExoPlayerFactory.newSimpleInstance(applicationContext, rendererFactory, trackSelector).apply {
+            setAudioAttributes(audioAttributes, true)
+        }
         player?.playWhenReady = false
         player?.repeatMode = when (options.options[ClapprOption.LOOP.value]) {
             true -> Player.REPEAT_MODE_ONE

--- a/clappr/src/main/kotlin/io/clappr/player/playback/ExoPlayerPlayBack.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/playback/ExoPlayerPlayBack.kt
@@ -61,7 +61,9 @@ open class ExoPlayerPlayback(source: String, mimeType: String? = null, options: 
     private val MIN_DVR_LIVE_DRIFT = 5
     private val DEFAULT_SYNC_BUFFER_IN_SECONDS = DefaultLoadControl.DEFAULT_MIN_BUFFER_MS / ONE_SECOND_IN_MILLIS
 
-    open val minDvrSize by lazy { options[ClapprOption.MIN_DVR_SIZE.value] as? Int ?: DEFAULT_MIN_DVR_SIZE }
+    open val minDvrSize by lazy {
+        options[ClapprOption.MIN_DVR_SIZE.value] as? Int ?: DEFAULT_MIN_DVR_SIZE
+    }
 
     protected var player: SimpleExoPlayer? = null
     protected val bandwidthMeter = DefaultBandwidthMeter()
@@ -121,10 +123,12 @@ open class ExoPlayerPlayback(source: String, mimeType: String? = null, options: 
     private val syncBufferInSeconds = if (mediaType == MediaType.LIVE) DEFAULT_SYNC_BUFFER_IN_SECONDS + MIN_DVR_LIVE_DRIFT else 0
 
     override val duration: Double
-        get() = player?.duration?.let { (it.toDouble() / ONE_SECOND_IN_MILLIS) - syncBufferInSeconds } ?: Double.NaN
+        get() = player?.duration?.let { (it.toDouble() / ONE_SECOND_IN_MILLIS) - syncBufferInSeconds }
+                ?: Double.NaN
 
     override val position: Double
-        get() = player?.currentPosition?.let { min(it.toDouble() / ONE_SECOND_IN_MILLIS, duration) } ?: Double.NaN
+        get() = player?.currentPosition?.let { min(it.toDouble() / ONE_SECOND_IN_MILLIS, duration) }
+                ?: Double.NaN
 
     override val state: State
         get() = currentState
@@ -347,7 +351,7 @@ open class ExoPlayerPlayback(source: String, mimeType: String? = null, options: 
         configureTrackSelector()
 
         val audioAttributes = AudioAttributes.Builder()
-            .setContentType(C.CONTENT_TYPE_MOVIE)
+                .setContentType(C.CONTENT_TYPE_MOVIE)
                 .setUsage(C.USAGE_MEDIA)
                 .build()
 
@@ -398,8 +402,9 @@ open class ExoPlayerPlayback(source: String, mimeType: String? = null, options: 
                         addListener(mainHandler, drmEventsListeners)
                         drmLicenses?.let { setMode(DefaultDrmSessionManager.MODE_QUERY, it) }
                     }
+        } catch (drmException: UnsupportedDrmException) {
+            handleError(drmException)
         }
-        catch (drmException: UnsupportedDrmException) { handleError(drmException) }
 
         return drmSessionManager
     }
@@ -624,11 +629,13 @@ open class ExoPlayerPlayback(source: String, mimeType: String? = null, options: 
     }
 
     private fun createAudioMediaOption(format: Format, raw: Any?): MediaOption {
-        return format.language?.let { createAudioMediaOptionFromLanguage(it, raw) } ?: createOriginalOption(raw)
+        return format.language?.let { createAudioMediaOptionFromLanguage(it, raw) }
+                ?: createOriginalOption(raw)
     }
 
     private fun createSubtitleMediaOption(format: Format, raw: Any?): MediaOption {
-        return format.language?.let { createSubtitleMediaOptionFromLanguage(it, raw) } ?: SUBTITLE_OFF
+        return format.language?.let { createSubtitleMediaOptionFromLanguage(it, raw) }
+                ?: SUBTITLE_OFF
     }
 
     private fun createMediaInfo(renderedTextIndex: Int, trackGroupIndex: Int, formatIndex: Int) =
@@ -692,7 +699,7 @@ open class ExoPlayerPlayback(source: String, mimeType: String? = null, options: 
         }
     }
 
-    inner class ExoplayerEventsListener: Player.EventListener {
+    inner class ExoplayerEventsListener : Player.EventListener {
         override fun onPlayerStateChanged(playWhenReady: Boolean, playbackState: Int) {
             updateState(playWhenReady, playbackState)
         }

--- a/clappr/src/main/kotlin/io/clappr/player/playback/ExoPlayerPlayBack.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/playback/ExoPlayerPlayBack.kt
@@ -353,11 +353,11 @@ open class ExoPlayerPlayback(source: String, mimeType: String? = null, options: 
 
         player = ExoPlayerFactory.newSimpleInstance(applicationContext, rendererFactory, trackSelector).apply {
             setAudioAttributes(audioAttributes, true)
-        }
-        player?.playWhenReady = false
-        player?.repeatMode = when (options.options[ClapprOption.LOOP.value]) {
-            true -> Player.REPEAT_MODE_ONE
-            else -> Player.REPEAT_MODE_OFF
+            playWhenReady = false
+            repeatMode = when (options.options[ClapprOption.LOOP.value]) {
+                true -> Player.REPEAT_MODE_ONE
+                else -> Player.REPEAT_MODE_OFF
+            }
         }
 
         addListeners()

--- a/clappr/src/main/kotlin/io/clappr/player/playback/ExoPlayerPlayBack.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/playback/ExoPlayerPlayBack.kt
@@ -356,7 +356,9 @@ open class ExoPlayerPlayback(source: String, mimeType: String? = null, options: 
                 .build()
 
         player = ExoPlayerFactory.newSimpleInstance(applicationContext, rendererFactory, trackSelector).apply {
-            setAudioAttributes(audioAttributes, true)
+            val handleAudioFocus = options.options[ClapprOption.HANDLE_AUDIO_FOCUS.value] as? Boolean
+                    ?: false
+            setAudioAttributes(audioAttributes, handleAudioFocus)
             playWhenReady = false
             repeatMode = when (options.options[ClapprOption.LOOP.value]) {
                 true -> Player.REPEAT_MODE_ONE

--- a/clappr/src/main/kotlin/io/clappr/player/playback/ExoPlayerPlayBack.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/playback/ExoPlayerPlayBack.kt
@@ -230,6 +230,9 @@ open class ExoPlayerPlayback(source: String, mimeType: String? = null, options: 
                     mediaType == MediaType.VOD
         } ?: false
 
+    open val handleAudioFocus: Boolean
+        get() = options.options[ClapprOption.HANDLE_AUDIO_FOCUS.value] as? Boolean ?: false
+
     init {
         playerView.useController = false
         playerView.subtitleView?.setStyle(getSubtitleStyle())
@@ -356,8 +359,6 @@ open class ExoPlayerPlayback(source: String, mimeType: String? = null, options: 
                 .build()
 
         player = ExoPlayerFactory.newSimpleInstance(applicationContext, rendererFactory, trackSelector).apply {
-            val handleAudioFocus = options.options[ClapprOption.HANDLE_AUDIO_FOCUS.value] as? Boolean
-                    ?: false
             setAudioAttributes(audioAttributes, handleAudioFocus)
             playWhenReady = false
             repeatMode = when (options.options[ClapprOption.LOOP.value]) {


### PR DESCRIPTION
## Goal
Enable Audio Focus handling via ExoPlayer. The feature can be enabled by the HANDLE_AUDIO_FOCUS option and is disabled by default.

Default ExoPlayer behavior is playback's volume being diminished after audio focus loss and restored after regaining focus.

## How to test
- Run unit tests: `./gradlew clean test`