### PR TITLE
External Input Devices Support

### DIFF
--- a/clappr/src/main/kotlin/io/clappr/player/Player.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/Player.kt
@@ -282,7 +282,7 @@ open class Player(private val base: BaseObject = BaseObject(),
         core?.fullscreenState = if (this.fullscreen) Core.FullscreenState.FULLSCREEN else Core.FullscreenState.EMBEDDED
     }
 
-    fun holdKeyEvent(keyCode: Int, event: KeyEvent) {
-        externalInputDevice?.holdKeyEvent(keyCode, event)
+    fun holdKeyEvent(event: KeyEvent) {
+        externalInputDevice?.holdKeyEvent(event)
     }
 }

--- a/clappr/src/main/kotlin/io/clappr/player/Player.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/Player.kt
@@ -3,6 +3,7 @@ package io.clappr.player
 import android.app.Fragment
 import android.content.Context
 import android.os.Bundle
+import android.view.KeyEvent
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -12,6 +13,8 @@ import io.clappr.player.components.Playback
 import io.clappr.player.extensions.context.isRunningInAndroidTvDevice
 import io.clappr.player.plugin.PlaybackConfig
 import io.clappr.player.plugin.PluginConfig
+import io.clappr.player.plugin.core.externalinput.ExternalInputDevice
+import io.clappr.player.plugin.core.externalinput.ExternalInputPlugin
 
 /**
  *  Main Player class.
@@ -36,6 +39,9 @@ open class Player(private val base: BaseObject = BaseObject(),
             BaseObject.applicationContext = applicationContext
         }
     }
+
+    private val externalInputDevice: ExternalInputDevice?
+        get() = (core?.plugins?.firstOrNull { it.name == ExternalInputPlugin.name }) as? ExternalInputDevice
 
     init {
         Event.values().forEach { playbackEventsToListen.add(it.value) }
@@ -274,5 +280,9 @@ open class Player(private val base: BaseObject = BaseObject(),
 
     private fun updateCoreFullScreenStatus() {
         core?.fullscreenState = if (this.fullscreen) Core.FullscreenState.FULLSCREEN else Core.FullscreenState.EMBEDDED
+    }
+
+    fun holdKeyEvent(keyCode: Int, event: KeyEvent) {
+        externalInputDevice?.holdKeyEvent(keyCode, event)
     }
 }

--- a/clappr/src/main/kotlin/io/clappr/player/base/Events.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/base/Events.kt
@@ -132,9 +132,9 @@ enum class Event(val value: String) {
     DID_LOOP("didLoop"),
 
     /**
-     * A key was pressed from an external device
+     * A input key was received from an external device
      * **/
-    KEY_PRESSED("keyPressed")
+    DID_RECEIVE_INPUT_KEY("didReceiveInputKey")
 }
 
 /**
@@ -161,7 +161,7 @@ enum class EventData(val value: String) {
     BITRATE("bitrate"),
 
     /**
-     * [Event.KEY_PRESSED] data
+     * [Event.DID_RECEIVE_INPUT_KEY] data
      *
      * Type: Int
      *
@@ -170,7 +170,7 @@ enum class EventData(val value: String) {
     PRESSED_KEY_CODE("pressedKeyCode"),
 
     /**
-     * [Event.KEY_PRESSED] data
+     * [Event.DID_RECEIVE_INPUT_KEY] data
      *
      * Type: Int
      *

--- a/clappr/src/main/kotlin/io/clappr/player/base/Events.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/base/Events.kt
@@ -1,6 +1,8 @@
 package io.clappr.player.base
 
 import android.support.annotation.Keep
+import io.clappr.player.base.keys.Action
+import io.clappr.player.base.keys.Key
 
 @Keep
 enum class Event(val value: String) {
@@ -127,7 +129,12 @@ enum class Event(val value: String) {
     /**
      * There was a video loop
      */
-    DID_LOOP("didLoop")
+    DID_LOOP("didLoop"),
+
+    /**
+     * A key was pressed from an external device
+     * **/
+    KEY_PRESSED("keyPressed")
 }
 
 /**
@@ -151,5 +158,23 @@ enum class EventData(val value: String) {
      *
      * Bits per second
      */
-    BITRATE("bitrate")
+    BITRATE("bitrate"),
+
+    /**
+     * [Event.KEY_PRESSED] data
+     *
+     * Type: Int
+     *
+     * Pressed key. Can be any of keys specified in [Key] class
+     */
+    PRESSED_KEY_CODE("pressedKeyCode"),
+
+    /**
+     * [Event.KEY_PRESSED] data
+     *
+     * Type: Int
+     *
+     * Pressed key action. Can be [Action.UP] or [Action.DOWN]
+     */
+    PRESSED_KEY_ACTION("pressedKeyAction")
 }

--- a/clappr/src/main/kotlin/io/clappr/player/base/Events.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/base/Events.kt
@@ -165,16 +165,16 @@ enum class EventData(val value: String) {
      *
      * Type: Int
      *
-     * Pressed key. Can be any of keys specified in [Key] class
+     * Input key received. Can be any of keys specified in [Key] class
      */
-    PRESSED_KEY_CODE("pressedKeyCode"),
+    INPUT_KEY_CODE("inputKeyCode"),
 
     /**
      * [Event.DID_RECEIVE_INPUT_KEY] data
      *
      * Type: Int
      *
-     * Pressed key action. Can be [Action.UP] or [Action.DOWN]
+     * Input key received. Can be [Action.UP] or [Action.DOWN]
      */
-    PRESSED_KEY_ACTION("pressedKeyAction")
+    INPUT_KEY_ACTION("inputKeyAction")
 }

--- a/clappr/src/main/kotlin/io/clappr/player/base/Events.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/base/Events.kt
@@ -163,7 +163,7 @@ enum class EventData(val value: String) {
     /**
      * [Event.DID_RECEIVE_INPUT_KEY] data
      *
-     * Type: Int
+     * Type: String
      *
      * Input key received. Can be any of keys specified in [Key] class
      */
@@ -172,7 +172,7 @@ enum class EventData(val value: String) {
     /**
      * [Event.DID_RECEIVE_INPUT_KEY] data
      *
-     * Type: Int
+     * Type: String
      *
      * Input key received. Can be [Action.UP] or [Action.DOWN]
      */

--- a/clappr/src/main/kotlin/io/clappr/player/base/keys/Action.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/base/keys/Action.kt
@@ -6,6 +6,6 @@ enum class Action(val value: String) {
     DOWN("down");
 
     companion object {
-        fun getByValue(value: String) = values().firstOrNull { it.value == value }?.let { it }
+        fun getByValue(value: String) = values().firstOrNull { it.value == value }
     }
 }

--- a/clappr/src/main/kotlin/io/clappr/player/base/keys/Action.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/base/keys/Action.kt
@@ -1,5 +1,5 @@
 package io.clappr.player.base.keys
 
-enum class Action {
-    UNDEFINED, UP, DOWN
+enum class Action(val value: String) {
+    UNDEFINED("undefined"), UP("up"), DOWN("down")
 }

--- a/clappr/src/main/kotlin/io/clappr/player/base/keys/Action.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/base/keys/Action.kt
@@ -1,0 +1,5 @@
+package io.clappr.player.base.keys
+
+enum class Action {
+    UNDEFINED, UP, DOWN
+}

--- a/clappr/src/main/kotlin/io/clappr/player/base/keys/Action.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/base/keys/Action.kt
@@ -1,5 +1,11 @@
 package io.clappr.player.base.keys
 
 enum class Action(val value: String) {
-    UNDEFINED("undefined"), UP("up"), DOWN("down")
+    UNDEFINED("undefined"),
+    UP("up"),
+    DOWN("down");
+
+    companion object {
+        fun getByValue(value: String) = values().firstOrNull { it.value == value }?.let { it }
+    }
 }

--- a/clappr/src/main/kotlin/io/clappr/player/base/keys/Key.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/base/keys/Key.kt
@@ -8,6 +8,6 @@ enum class Key(val value: String) {
     PLAY_PAUSE("playPause");
 
     companion object {
-        fun getByValue(value: String) = values().firstOrNull { it.value == value }?.let { it }
+        fun getByValue(value: String) = values().firstOrNull { it.value == value }
     }
 }

--- a/clappr/src/main/kotlin/io/clappr/player/base/keys/Key.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/base/keys/Key.kt
@@ -3,7 +3,8 @@ package io.clappr.player.base.keys
 enum class Key(val value: String) {
     UNDEFINED("undefined"),
     PLAY("play"),
-    PAUSE("pause");
+    PAUSE("pause"),
+    STOP("strop");
 
     companion object {
         fun getByValue(value: String) = values().firstOrNull { it.value == value }?.let { it }

--- a/clappr/src/main/kotlin/io/clappr/player/base/keys/Key.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/base/keys/Key.kt
@@ -4,7 +4,7 @@ enum class Key(val value: String) {
     UNDEFINED("undefined"),
     PLAY("play"),
     PAUSE("pause"),
-    STOP("strop"),
+    STOP("stop"),
     PLAY_PAUSE("playPause");
 
     companion object {

--- a/clappr/src/main/kotlin/io/clappr/player/base/keys/Key.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/base/keys/Key.kt
@@ -1,5 +1,7 @@
 package io.clappr.player.base.keys
 
 enum class Key(val value: String) {
-    UNDEFINED("undefined"), PLAY("play")
+    UNDEFINED("undefined"),
+    PLAY("play"),
+    PAUSE("pause")
 }

--- a/clappr/src/main/kotlin/io/clappr/player/base/keys/Key.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/base/keys/Key.kt
@@ -3,5 +3,9 @@ package io.clappr.player.base.keys
 enum class Key(val value: String) {
     UNDEFINED("undefined"),
     PLAY("play"),
-    PAUSE("pause")
+    PAUSE("pause");
+
+    companion object {
+        fun getByValue(value: String) = values().firstOrNull { it.value == value }?.let { it }
+    }
 }

--- a/clappr/src/main/kotlin/io/clappr/player/base/keys/Key.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/base/keys/Key.kt
@@ -1,0 +1,5 @@
+package io.clappr.player.base.keys
+
+enum class Key {
+    UNDEFINED, PLAY
+}

--- a/clappr/src/main/kotlin/io/clappr/player/base/keys/Key.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/base/keys/Key.kt
@@ -1,5 +1,5 @@
 package io.clappr.player.base.keys
 
-enum class Key {
-    UNDEFINED, PLAY
+enum class Key(val value: String) {
+    UNDEFINED("undefined"), PLAY("play")
 }

--- a/clappr/src/main/kotlin/io/clappr/player/base/keys/Key.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/base/keys/Key.kt
@@ -4,7 +4,8 @@ enum class Key(val value: String) {
     UNDEFINED("undefined"),
     PLAY("play"),
     PAUSE("pause"),
-    STOP("strop");
+    STOP("strop"),
+    PLAY_PAUSE("playPause");
 
     companion object {
         fun getByValue(value: String) = values().firstOrNull { it.value == value }?.let { it }

--- a/clappr/src/main/kotlin/io/clappr/player/plugin/core/externalinput/ExternalInputDevice.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/plugin/core/externalinput/ExternalInputDevice.kt
@@ -3,5 +3,5 @@ package io.clappr.player.plugin.core.externalinput
 import android.view.KeyEvent
 
 interface ExternalInputDevice {
-    fun holdKeyEvent(keyCode: Int, event: KeyEvent)
+    fun holdKeyEvent(event: KeyEvent)
 }

--- a/clappr/src/main/kotlin/io/clappr/player/plugin/core/externalinput/ExternalInputDevice.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/plugin/core/externalinput/ExternalInputDevice.kt
@@ -1,0 +1,7 @@
+package io.clappr.player.plugin.core.externalinput
+
+import android.view.KeyEvent
+
+interface ExternalInputDevice {
+    fun holdKeyEvent(keyCode: Int, event: KeyEvent)
+}

--- a/clappr/src/main/kotlin/io/clappr/player/plugin/core/externalinput/ExternalInputPlugin.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/plugin/core/externalinput/ExternalInputPlugin.kt
@@ -1,7 +1,12 @@
 package io.clappr.player.plugin.core.externalinput
 
+import android.os.Bundle
 import android.view.KeyEvent
+import io.clappr.player.base.Event
+import io.clappr.player.base.EventData
 import io.clappr.player.base.NamedType
+import io.clappr.player.base.keys.Action
+import io.clappr.player.base.keys.Key
 import io.clappr.player.components.Core
 import io.clappr.player.log.Logger
 import io.clappr.player.plugin.PluginEntry
@@ -15,6 +20,24 @@ class ExternalInputPlugin(core: Core) : CorePlugin(core, name = name), ExternalI
     }
 
     override fun holdKeyEvent(keyCode: Int, event: KeyEvent) {
-        Logger.debug(name, "Keycode: $keyCode, Event: $event")
+
+        val aKeyCode = getKeyCode(event.keyCode)
+        val actionCode = getActionCode(event.action)
+
+        core.trigger(Event.KEY_PRESSED.value, Bundle().apply {
+            putString(EventData.PRESSED_KEY_CODE.value, aKeyCode)
+            putString(EventData.PRESSED_KEY_ACTION.value, actionCode)
+        })
+    }
+
+    private fun getKeyCode(keyCode: Int) = when (keyCode) {
+        KeyEvent.KEYCODE_MEDIA_PLAY -> Key.PLAY.name
+        else -> Key.UNDEFINED.name
+    }
+
+    private fun getActionCode(action: Int) = when (action) {
+        KeyEvent.ACTION_UP -> Action.UP.name
+        KeyEvent.ACTION_DOWN -> Action.DOWN.name
+        else -> Action.UNDEFINED.name
     }
 }

--- a/clappr/src/main/kotlin/io/clappr/player/plugin/core/externalinput/ExternalInputPlugin.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/plugin/core/externalinput/ExternalInputPlugin.kt
@@ -32,6 +32,7 @@ class ExternalInputPlugin(core: Core) : CorePlugin(core, name = name), ExternalI
 
     private fun getKeyCode(keyCode: Int) = when (keyCode) {
         KeyEvent.KEYCODE_MEDIA_PLAY -> Key.PLAY.value
+        KeyEvent.KEYCODE_MEDIA_PAUSE -> Key.PAUSE.value
         else -> Key.UNDEFINED.value
     }
 

--- a/clappr/src/main/kotlin/io/clappr/player/plugin/core/externalinput/ExternalInputPlugin.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/plugin/core/externalinput/ExternalInputPlugin.kt
@@ -18,7 +18,6 @@ class ExternalInputPlugin(core: Core) : CorePlugin(core, name = name), ExternalI
         val entry = PluginEntry.Core(name = name, factory = { core -> ExternalInputPlugin(core) })
     }
 
-
     private val supportedKeys = hashMapOf(
             KeyEvent.KEYCODE_MEDIA_PLAY to Key.PLAY.value,
             KeyEvent.KEYCODE_MEDIA_PAUSE to Key.PAUSE.value,

--- a/clappr/src/main/kotlin/io/clappr/player/plugin/core/externalinput/ExternalInputPlugin.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/plugin/core/externalinput/ExternalInputPlugin.kt
@@ -27,8 +27,8 @@ class ExternalInputPlugin(core: Core) : CorePlugin(core, name = name), ExternalI
     
     override fun holdKeyEvent(event: KeyEvent) {
         core.trigger(Event.DID_RECEIVE_INPUT_KEY.value, Bundle().apply {
-            putString(EventData.PRESSED_KEY_CODE.value, getKeyCode(event.keyCode))
-            putString(EventData.PRESSED_KEY_ACTION.value, getActionCode(event.action))
+            putString(EventData.INPUT_KEY_CODE.value, getKeyCode(event.keyCode))
+            putString(EventData.INPUT_KEY_ACTION.value, getActionCode(event.action))
         })
     }
 

--- a/clappr/src/main/kotlin/io/clappr/player/plugin/core/externalinput/ExternalInputPlugin.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/plugin/core/externalinput/ExternalInputPlugin.kt
@@ -33,6 +33,7 @@ class ExternalInputPlugin(core: Core) : CorePlugin(core, name = name), ExternalI
     private fun getKeyCode(keyCode: Int) = when (keyCode) {
         KeyEvent.KEYCODE_MEDIA_PLAY -> Key.PLAY.value
         KeyEvent.KEYCODE_MEDIA_PAUSE -> Key.PAUSE.value
+        KeyEvent.KEYCODE_MEDIA_STOP -> Key.STOP.value
         else -> Key.UNDEFINED.value
     }
 

--- a/clappr/src/main/kotlin/io/clappr/player/plugin/core/externalinput/ExternalInputPlugin.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/plugin/core/externalinput/ExternalInputPlugin.kt
@@ -19,13 +19,13 @@ class ExternalInputPlugin(core: Core) : CorePlugin(core, name = name), ExternalI
         val entry = PluginEntry.Core(name = name, factory = { core -> ExternalInputPlugin(core) })
     }
 
-    override fun holdKeyEvent(keyCode: Int, event: KeyEvent) {
+    override fun holdKeyEvent(event: KeyEvent) {
 
-        val aKeyCode = getKeyCode(event.keyCode)
+        val keyCode = getKeyCode(event.keyCode)
         val actionCode = getActionCode(event.action)
 
         core.trigger(Event.KEY_PRESSED.value, Bundle().apply {
-            putString(EventData.PRESSED_KEY_CODE.value, aKeyCode)
+            putString(EventData.PRESSED_KEY_CODE.value, keyCode)
             putString(EventData.PRESSED_KEY_ACTION.value, actionCode)
         })
     }

--- a/clappr/src/main/kotlin/io/clappr/player/plugin/core/externalinput/ExternalInputPlugin.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/plugin/core/externalinput/ExternalInputPlugin.kt
@@ -19,11 +19,13 @@ class ExternalInputPlugin(core: Core) : CorePlugin(core, name = name), ExternalI
         val entry = PluginEntry.Core(name = name, factory = { core -> ExternalInputPlugin(core) })
     }
 
-    override fun holdKeyEvent(event: KeyEvent) {
 
-        val keyCode = getKeyCode(event.keyCode)
-        val actionCode = getActionCode(event.action)
-
+    private val supportedKeys = hashMapOf(
+            KeyEvent.KEYCODE_MEDIA_PLAY to Key.PLAY.value,
+            KeyEvent.KEYCODE_MEDIA_PAUSE to Key.PAUSE.value,
+            KeyEvent.KEYCODE_MEDIA_STOP to Key.STOP.value,
+            KeyEvent.KEYCODE_MEDIA_PLAY_PAUSE to Key.PLAY_PAUSE.value)
+    
     override fun holdKeyEvent(event: KeyEvent) {
         core.trigger(Event.KEY_PRESSED.value, Bundle().apply {
             putString(EventData.PRESSED_KEY_CODE.value, getKeyCode(event.keyCode))
@@ -31,13 +33,7 @@ class ExternalInputPlugin(core: Core) : CorePlugin(core, name = name), ExternalI
         })
     }
 
-    private fun getKeyCode(keyCode: Int) = when (keyCode) {
-        KeyEvent.KEYCODE_MEDIA_PLAY -> Key.PLAY.value
-        KeyEvent.KEYCODE_MEDIA_PAUSE -> Key.PAUSE.value
-        KeyEvent.KEYCODE_MEDIA_STOP -> Key.STOP.value
-        KeyEvent.KEYCODE_MEDIA_PLAY_PAUSE -> Key.PLAY_PAUSE.value
-        else -> Key.UNDEFINED.value
-    }
+    private fun getKeyCode(keyCode: Int) = supportedKeys[keyCode] ?: Key.UNDEFINED.value
 
     private fun getActionCode(action: Int) = when (action) {
         KeyEvent.ACTION_UP -> Action.UP.value

--- a/clappr/src/main/kotlin/io/clappr/player/plugin/core/externalinput/ExternalInputPlugin.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/plugin/core/externalinput/ExternalInputPlugin.kt
@@ -31,13 +31,13 @@ class ExternalInputPlugin(core: Core) : CorePlugin(core, name = name), ExternalI
     }
 
     private fun getKeyCode(keyCode: Int) = when (keyCode) {
-        KeyEvent.KEYCODE_MEDIA_PLAY -> Key.PLAY.name
-        else -> Key.UNDEFINED.name
+        KeyEvent.KEYCODE_MEDIA_PLAY -> Key.PLAY.value
+        else -> Key.UNDEFINED.value
     }
 
     private fun getActionCode(action: Int) = when (action) {
-        KeyEvent.ACTION_UP -> Action.UP.name
-        KeyEvent.ACTION_DOWN -> Action.DOWN.name
-        else -> Action.UNDEFINED.name
+        KeyEvent.ACTION_UP -> Action.UP.value
+        KeyEvent.ACTION_DOWN -> Action.DOWN.value
+        else -> Action.UNDEFINED.value
     }
 }

--- a/clappr/src/main/kotlin/io/clappr/player/plugin/core/externalinput/ExternalInputPlugin.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/plugin/core/externalinput/ExternalInputPlugin.kt
@@ -1,14 +1,20 @@
 package io.clappr.player.plugin.core.externalinput
 
+import android.view.KeyEvent
 import io.clappr.player.base.NamedType
 import io.clappr.player.components.Core
+import io.clappr.player.log.Logger
 import io.clappr.player.plugin.PluginEntry
 import io.clappr.player.plugin.core.CorePlugin
 
-class ExternalInputPlugin(core: Core) : CorePlugin(core, name = name) {
+class ExternalInputPlugin(core: Core) : CorePlugin(core, name = name), ExternalInputDevice {
     companion object : NamedType {
         override val name = "externalInputPlugin"
 
         val entry = PluginEntry.Core(name = name, factory = { core -> ExternalInputPlugin(core) })
+    }
+
+    override fun holdKeyEvent(keyCode: Int, event: KeyEvent) {
+        Logger.debug(name, "Keycode: $keyCode, Event: $event")
     }
 }

--- a/clappr/src/main/kotlin/io/clappr/player/plugin/core/externalinput/ExternalInputPlugin.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/plugin/core/externalinput/ExternalInputPlugin.kt
@@ -8,7 +8,6 @@ import io.clappr.player.base.NamedType
 import io.clappr.player.base.keys.Action
 import io.clappr.player.base.keys.Key
 import io.clappr.player.components.Core
-import io.clappr.player.log.Logger
 import io.clappr.player.plugin.PluginEntry
 import io.clappr.player.plugin.core.CorePlugin
 
@@ -27,7 +26,7 @@ class ExternalInputPlugin(core: Core) : CorePlugin(core, name = name), ExternalI
             KeyEvent.KEYCODE_MEDIA_PLAY_PAUSE to Key.PLAY_PAUSE.value)
     
     override fun holdKeyEvent(event: KeyEvent) {
-        core.trigger(Event.KEY_PRESSED.value, Bundle().apply {
+        core.trigger(Event.DID_RECEIVE_INPUT_KEY.value, Bundle().apply {
             putString(EventData.PRESSED_KEY_CODE.value, getKeyCode(event.keyCode))
             putString(EventData.PRESSED_KEY_ACTION.value, getActionCode(event.action))
         })

--- a/clappr/src/main/kotlin/io/clappr/player/plugin/core/externalinput/ExternalInputPlugin.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/plugin/core/externalinput/ExternalInputPlugin.kt
@@ -24,9 +24,10 @@ class ExternalInputPlugin(core: Core) : CorePlugin(core, name = name), ExternalI
         val keyCode = getKeyCode(event.keyCode)
         val actionCode = getActionCode(event.action)
 
+    override fun holdKeyEvent(event: KeyEvent) {
         core.trigger(Event.KEY_PRESSED.value, Bundle().apply {
-            putString(EventData.PRESSED_KEY_CODE.value, keyCode)
-            putString(EventData.PRESSED_KEY_ACTION.value, actionCode)
+            putString(EventData.PRESSED_KEY_CODE.value, getKeyCode(event.keyCode))
+            putString(EventData.PRESSED_KEY_ACTION.value, getActionCode(event.action))
         })
     }
 
@@ -34,6 +35,7 @@ class ExternalInputPlugin(core: Core) : CorePlugin(core, name = name), ExternalI
         KeyEvent.KEYCODE_MEDIA_PLAY -> Key.PLAY.value
         KeyEvent.KEYCODE_MEDIA_PAUSE -> Key.PAUSE.value
         KeyEvent.KEYCODE_MEDIA_STOP -> Key.STOP.value
+        KeyEvent.KEYCODE_MEDIA_PLAY_PAUSE -> Key.PLAY_PAUSE.value
         else -> Key.UNDEFINED.value
     }
 

--- a/clappr/src/main/kotlin/io/clappr/player/plugin/core/externalinput/ExternalInputPlugin.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/plugin/core/externalinput/ExternalInputPlugin.kt
@@ -1,0 +1,14 @@
+package io.clappr.player.plugin.core.externalinput
+
+import io.clappr.player.base.NamedType
+import io.clappr.player.components.Core
+import io.clappr.player.plugin.PluginEntry
+import io.clappr.player.plugin.core.CorePlugin
+
+class ExternalInputPlugin(core: Core) : CorePlugin(core, name = name) {
+    companion object : NamedType {
+        override val name = "externalInputPlugin"
+
+        val entry = PluginEntry.Core(name = name, factory = { core -> ExternalInputPlugin(core) })
+    }
+}

--- a/clappr/src/test/kotlin/io/clappr/player/PlayerTest.kt
+++ b/clappr/src/test/kotlin/io/clappr/player/PlayerTest.kt
@@ -430,7 +430,6 @@ open class PlayerTest {
 
     @Test
     fun `should pass key event to external input class`(){
-
         val expectedKeyEvent = KeyEvent(1, 2, 3, 4, 5)
 
         ExternalInputPluginTest.keyEvent = null

--- a/clappr/src/test/kotlin/io/clappr/player/PlayerTest.kt
+++ b/clappr/src/test/kotlin/io/clappr/player/PlayerTest.kt
@@ -46,7 +46,7 @@ open class PlayerTest {
     }
 
     @Test
-    fun shouldHaveInvalidStatesBeforeConfigure() {
+    fun `should have invalid states before configure`() {
         assertEquals("valid duration", Double.NaN, player.duration, 0.0)
         assertEquals("valid position", Double.NaN, player.position, 0.0)
 
@@ -58,7 +58,7 @@ open class PlayerTest {
     }
 
     @SuppressLint("IgnoreWithoutReason") @Ignore @Test
-    fun shouldHaveInvalidStatesWithUnsupportedMedia() {
+    fun `should have invalid states with unsupported media`() {
         player.configure(Options(source = ""))
 
         assertEquals("valid duration", Double.NaN, player.duration, 0.0)
@@ -74,7 +74,7 @@ open class PlayerTest {
     }
 
     @Test
-    fun configuredPlayer() {
+    fun `configured player`() {
         player.configure(Options(source = "valid"))
 
         assertNotEquals("invalid duration", Double.NaN, player.duration, 0.0)
@@ -87,7 +87,7 @@ open class PlayerTest {
     }
 
     @Test
-    fun shouldTriggerEvents() {
+    fun `should trigger events`() {
         var willPauseCalled = false
         var didPauseCalled = false
         player.on(Event.WILL_PAUSE.value) { willPauseCalled = true }
@@ -101,7 +101,7 @@ open class PlayerTest {
     }
 
     @Test
-    fun playerStates() {
+    fun `player states`() {
         assertEquals("invalid state (not NONE)", Player.State.NONE, player.state)
 
         player.configure(Options(source = "valid"))
@@ -120,7 +120,7 @@ open class PlayerTest {
     }
 
     @Test
-    fun shouldUnbindOnConfigure() {
+    fun `should unbind on configure`() {
         var willPauseCalled = false
         var didPauseCalled = false
 
@@ -158,7 +158,7 @@ open class PlayerTest {
      * configure.
      */
     @Test
-    fun shouldCoreChangeOptionsOnPlayerConfigure() {
+    fun `should core change options on player configure`() {
         val expectedFirstOption = "first option"
         val expectedSecondOption = "second option"
 
@@ -186,7 +186,7 @@ open class PlayerTest {
      * configure.
      */
     @Test
-    fun shouldCoreChangeMimeTypeOnPlayerConfigure() {
+    fun `should core change mime type on player configure`() {
         val expectedFirstMimeType = "mimeType"
         val expectedSecondMimeType = "other-mimeType"
 
@@ -214,7 +214,7 @@ open class PlayerTest {
      * configure.
      */
     @Test
-    fun shouldCoreChangeMimeTypeOnPlayerLoad() {
+    fun `should core change mime type on player load`() {
         val expectedFirstMimeType = "mimeType"
         val expectedSecondMimeType = "other-mimeType"
 
@@ -242,7 +242,7 @@ open class PlayerTest {
      * configure.
      */
     @Test
-    fun shouldCoreChangeSourceOnPlayerConfigure() {
+    fun `should core change source on player configure`() {
         val expectedFirstSource = "source"
         val expectedSecondSource = "other-source"
 
@@ -270,7 +270,7 @@ open class PlayerTest {
      * configure.
      */
     @Test
-    fun shouldCoreChangeSourceOnPlayerLoad() {
+    fun `should core change ource on player load`() {
         val expectedFirstSource = "source"
         val expectedSecondSource = "other-source"
 
@@ -299,7 +299,7 @@ open class PlayerTest {
      * trigger a WILL_PLAY event when the Playback play is called using the PlayerTestPlayback.
      */
     @Test
-    fun shouldCoreHaveSameInstanceOnPlayerConfigure() {
+    fun `should core have same instance on player configure`() {
         val expectedDistinctCoreId = 1
 
         val coreIdList = mutableSetOf<String>()
@@ -321,107 +321,107 @@ open class PlayerTest {
     }
 
     @Test
-    fun shouldListenReadyEventOutOfPlayer() {
+    fun `should listen ready event out of player`() {
         assertPlaybackEventWasTriggered(Event.READY.value)
     }
 
     @Test
-    fun shouldListenErrorEventOutOfPlayer() {
+    fun `should listen error event out of player`() {
         assertPlaybackEventWasTriggered(Event.ERROR.value)
     }
 
     @Test
-    fun shouldListenPlayingEventOutOfPlayer() {
+    fun `should listen playing event out of player`() {
         assertPlaybackEventWasTriggered(Event.PLAYING.value)
     }
 
     @Test
-    fun shouldListenDidCompleteEventOutOfPlayer() {
+    fun `should listen did complete event out of player`() {
         assertPlaybackEventWasTriggered(Event.DID_COMPLETE.value)
     }
 
     @Test
-    fun shouldListenDidPauseEventOutOfPlayer() {
+    fun `should listen did pause event out of player`() {
         assertPlaybackEventWasTriggered(Event.DID_PAUSE.value)
     }
 
     @Test
-    fun shouldListenStallingEventOutOfPlayer() {
+    fun `should listen stalling event out of player`() {
         assertPlaybackEventWasTriggered(Event.STALLING.value)
     }
 
     @Test
-    fun shouldListenDidStopEventOutOfPlayer() {
+    fun `should listen did stop event out of player`() {
         assertPlaybackEventWasTriggered(Event.DID_STOP.value)
     }
 
     @Test
-    fun shouldListenDidSeekEventOutOfPlayer() {
+    fun `should listen did seek event out of player`() {
         assertPlaybackEventWasTriggered(Event.DID_SEEK.value)
     }
 
     @Test
-    fun shouldListenDidUpdateBufferEventOutOfPlayer() {
+    fun `should listen did update buffer event out of player`() {
         assertPlaybackEventWasTriggered(Event.DID_UPDATE_BUFFER.value)
     }
 
     @Test
-    fun shouldListenDidUpdatePositionEventOutOfPlayer() {
+    fun `should listen did update position event outOf player`() {
         assertPlaybackEventWasTriggered(Event.DID_UPDATE_POSITION.value)
     }
 
     @Test
-    fun shouldListenWillPlayEventOutOfPlayer() {
+    fun `should listen will play event out of player`() {
         assertPlaybackEventWasTriggered(Event.WILL_PLAY.value)
     }
 
     @Test
-    fun shouldListenWillPauseEventOutOfPlayer() {
+    fun `should listen will pause event out of player`() {
         assertPlaybackEventWasTriggered(Event.WILL_PAUSE.value)
     }
 
     @Test
-    fun shouldListenWillSeekEventOutOfPlayer() {
+    fun `should listen will week event out of player`() {
         assertPlaybackEventWasTriggered(Event.WILL_SEEK.value)
     }
 
     @Test
-    fun shouldListenWillStopEventOutOfPlayer() {
+    fun `should listen will stop event out of player`() {
         assertPlaybackEventWasTriggered(Event.WILL_STOP.value)
     }
 
     @Test
-    fun shouldListenDidChangeDVRStatusEventOutOfPlayer() {
+    fun `should listen did change DVR status event out fo player`() {
         assertPlaybackEventWasTriggered(Event.DID_CHANGE_DVR_STATUS.value)
     }
 
     @Test
-    fun shouldListenDidChangeDVRAvailabilityEventOutOfPlayer() {
+    fun `should listen did change DVR availability event out of player`() {
         assertPlaybackEventWasTriggered(Event.DID_CHANGE_DVR_AVAILABILITY.value)
     }
 
     @Test
-    fun shouldListenDidUpdateBitrateEventOutOfPlayer() {
+    fun `should listen did updaten bitrate event out of player`() {
         assertPlaybackEventWasTriggered(Event.DID_UPDATE_BITRATE.value)
     }
 
     @Test
-    fun shouldListenMediaOptionUpdateEventOutOfPlayer() {
+    fun `should listen media option update event out of player`() {
         assertPlaybackEventWasTriggered(Event.MEDIA_OPTIONS_UPDATE.value)
     }
 
     @Test
-    fun shouldListenMediaOptionSelectedEventOutOfPlayerTriggeredByCore() {
+    fun `should listen media option selected event out of player triggered by core`() {
         assertCoreEventWasTriggered(Event.MEDIA_OPTIONS_SELECTED.value)
     }
 
     @Test
-    fun shouldListenRequestFullscreenEventOutOfPlayerTriggeredByCore() {
+    fun `should listen request fullscreen event out of player triggered by core`() {
         assertCoreEventWasTriggered(Event.REQUEST_FULLSCREEN.value)
     }
 
     @Test
-    fun shouldListenExitFullscreenEventOutOfPlayerTriggeredByCore() {
+    fun `should listen exit fullscreen event out of player triggered by core`() {
         assertCoreEventWasTriggered(Event.EXIT_FULLSCREEN.value)
     }
 

--- a/clappr/src/test/kotlin/io/clappr/player/PlayerTest.kt
+++ b/clappr/src/test/kotlin/io/clappr/player/PlayerTest.kt
@@ -431,10 +431,8 @@ open class PlayerTest {
     @Test
     fun `should pass key event to external input class`(){
 
-        val expectedKeyCode = 21
         val expectedKeyEvent = KeyEvent(1, 2, 3, 4, 5)
 
-        ExternalInputPluginTest.keyCode = null
         ExternalInputPluginTest.keyEvent = null
 
         Loader.register(ExternalInputPluginTest.entry)
@@ -442,9 +440,8 @@ open class PlayerTest {
         player = Player()
         player.configure(Options(source = "valid"))
 
-        player.holdKeyEvent(21, expectedKeyEvent)
+        player.holdKeyEvent(expectedKeyEvent)
 
-        assertEquals(expectedKeyCode, ExternalInputPluginTest.keyCode)
         assertEquals(expectedKeyEvent, ExternalInputPluginTest.keyEvent)
     }
 
@@ -597,12 +594,10 @@ open class PlayerTest {
 
             val entry = PluginEntry.Core(name = name, factory = { core -> ExternalInputPluginTest(core) })
 
-            var keyCode: Int? = null
             var keyEvent: KeyEvent? = null
         }
 
-        override fun holdKeyEvent(keyCode: Int, event: KeyEvent) {
-            Companion.keyCode = keyCode
+        override fun holdKeyEvent(event: KeyEvent) {
             keyEvent = event
 
         }

--- a/clappr/src/test/kotlin/io/clappr/player/PlayerTest.kt
+++ b/clappr/src/test/kotlin/io/clappr/player/PlayerTest.kt
@@ -598,7 +598,6 @@ open class PlayerTest {
 
         override fun holdKeyEvent(event: KeyEvent) {
             keyEvent = event
-
         }
     }
 }

--- a/clappr/src/test/kotlin/io/clappr/player/plugin/ExternalInputPluginTest.kt
+++ b/clappr/src/test/kotlin/io/clappr/player/plugin/ExternalInputPluginTest.kt
@@ -34,15 +34,13 @@ class ExternalInputPluginTest {
 
 
     @Test
-    fun `should trigger KEY_PRESSED event for PLAY button`(){
+    fun `should trigger KEY_PRESSED event for PLAY button`() {
         val expectedKeyCode = Key.PLAY.value
 
         var keyCode: String? = null
 
-        core.on(Event.KEY_PRESSED.value){ bundle ->
-            bundle?.let {
-                keyCode = it.getString(EventData.PRESSED_KEY_CODE.value)
-            }
+        core.on(Event.KEY_PRESSED.value) { bundle ->
+            bundle?.let { keyCode = it.getString(EventData.PRESSED_KEY_CODE.value) }
         }
 
         externalInputPlugin.holdKeyEvent(-1, KeyEvent(-1, KeyEvent.KEYCODE_MEDIA_PLAY))
@@ -52,15 +50,13 @@ class ExternalInputPluginTest {
 
 
     @Test
-    fun `should trigger KEY_PRESSED event with DOWN action`(){
+    fun `should trigger KEY_PRESSED event with DOWN action`() {
         val expectedActionCode = Action.DOWN.value
 
         var actionCode: String? = null
 
-        core.on(Event.KEY_PRESSED.value){ bundle ->
-            bundle?.let {
-                actionCode = it.getString(EventData.PRESSED_KEY_ACTION.value)
-            }
+        core.on(Event.KEY_PRESSED.value) { bundle ->
+            bundle?.let { actionCode = it.getString(EventData.PRESSED_KEY_ACTION.value) }
         }
 
         externalInputPlugin.holdKeyEvent(-1, KeyEvent(KeyEvent.ACTION_DOWN, -1))
@@ -69,19 +65,32 @@ class ExternalInputPluginTest {
     }
 
     @Test
-    fun `should trigger KEY_PRESSED event with UP action`(){
+    fun `should trigger KEY_PRESSED event with UP action`() {
         val expectedActionCode = Action.UP.value
 
         var actionCode: String? = null
 
-        core.on(Event.KEY_PRESSED.value){ bundle ->
-            bundle?.let {
-                actionCode = it.getString(EventData.PRESSED_KEY_ACTION.value)
-            }
+        core.on(Event.KEY_PRESSED.value) { bundle ->
+            bundle?.let { actionCode = it.getString(EventData.PRESSED_KEY_ACTION.value) }
         }
 
         externalInputPlugin.holdKeyEvent(-1, KeyEvent(KeyEvent.ACTION_UP, -1))
 
         assertEquals(expectedActionCode, actionCode)
+    }
+
+    @Test
+    fun `should trigger KEY_PRESSED event for PAUSE button`() {
+        val expectedKeyCode = Key.PAUSE.value
+
+        var keyCode: String? = null
+
+        core.on(Event.KEY_PRESSED.value) { bundle ->
+            bundle?.let { keyCode = it.getString(EventData.PRESSED_KEY_CODE.value) }
+        }
+
+        externalInputPlugin.holdKeyEvent(-1, KeyEvent(-1, KeyEvent.KEYCODE_MEDIA_PAUSE))
+
+        assertEquals(expectedKeyCode, keyCode)
     }
 }

--- a/clappr/src/test/kotlin/io/clappr/player/plugin/ExternalInputPluginTest.kt
+++ b/clappr/src/test/kotlin/io/clappr/player/plugin/ExternalInputPluginTest.kt
@@ -67,8 +67,8 @@ class ExternalInputPluginTest {
     private fun assertPressedKeyCodeEvent(expectedKeyCode: Key, keyToHold: Int){
         var keyCode: String? = null
 
-        core.on(Event.KEY_PRESSED.value) { bundle ->
-            bundle?.let { keyCode = it.getString(EventData.PRESSED_KEY_CODE.value) }
+        core.on(Event.DID_RECEIVE_INPUT_KEY.value) { bundle ->
+            bundle?.let { keyCode = it.getString(EventData.INPUT_KEY_CODE.value) }
         }
 
         externalInputPlugin.holdKeyEvent(KeyEvent(-1, keyToHold))
@@ -79,8 +79,8 @@ class ExternalInputPluginTest {
     private fun assertPressedAction(expectedActionCode: Action, actionKey: Int){
         var actionCode: String? = null
 
-        core.on(Event.KEY_PRESSED.value) { bundle ->
-            bundle?.let { actionCode = it.getString(EventData.PRESSED_KEY_ACTION.value) }
+        core.on(Event.DID_RECEIVE_INPUT_KEY.value) { bundle ->
+            bundle?.let { actionCode = it.getString(EventData.INPUT_KEY_ACTION.value) }
         }
 
         externalInputPlugin.holdKeyEvent(KeyEvent(actionKey, -1))

--- a/clappr/src/test/kotlin/io/clappr/player/plugin/ExternalInputPluginTest.kt
+++ b/clappr/src/test/kotlin/io/clappr/player/plugin/ExternalInputPluginTest.kt
@@ -108,4 +108,19 @@ class ExternalInputPluginTest {
 
         assertEquals(expectedKeyCode, keyCode)
     }
+
+    @Test
+    fun `should trigger KEY_PRESSED event for PLAY_PAUSE button`() {
+        val expectedKeyCode = Key.PLAY_PAUSE.value
+
+        var keyCode: String? = null
+
+        core.on(Event.KEY_PRESSED.value) { bundle ->
+            bundle?.let { keyCode = it.getString(EventData.PRESSED_KEY_CODE.value) }
+        }
+
+        externalInputPlugin.holdKeyEvent(KeyEvent(-1, KeyEvent.KEYCODE_MEDIA_PLAY_PAUSE))
+
+        assertEquals(expectedKeyCode, keyCode)
+    }
 }

--- a/clappr/src/test/kotlin/io/clappr/player/plugin/ExternalInputPluginTest.kt
+++ b/clappr/src/test/kotlin/io/clappr/player/plugin/ExternalInputPluginTest.kt
@@ -35,92 +35,56 @@ class ExternalInputPluginTest {
 
     @Test
     fun `should trigger KEY_PRESSED event for PLAY button`() {
-        val expectedKeyCode = Key.PLAY.value
-
-        var keyCode: String? = null
-
-        core.on(Event.KEY_PRESSED.value) { bundle ->
-            bundle?.let { keyCode = it.getString(EventData.PRESSED_KEY_CODE.value) }
-        }
-
-        externalInputPlugin.holdKeyEvent(KeyEvent(-1, KeyEvent.KEYCODE_MEDIA_PLAY))
-
-        assertEquals(expectedKeyCode, keyCode)
+        assertPressedKeyCodeEvent(Key.PLAY, KeyEvent.KEYCODE_MEDIA_PLAY)
     }
 
 
     @Test
     fun `should trigger KEY_PRESSED event with DOWN action`() {
-        val expectedActionCode = Action.DOWN.value
-
-        var actionCode: String? = null
-
-        core.on(Event.KEY_PRESSED.value) { bundle ->
-            bundle?.let { actionCode = it.getString(EventData.PRESSED_KEY_ACTION.value) }
-        }
-
-        externalInputPlugin.holdKeyEvent(KeyEvent(KeyEvent.ACTION_DOWN, -1))
-
-        assertEquals(expectedActionCode, actionCode)
+        assertPressedAction(Action.DOWN, KeyEvent.ACTION_DOWN)
     }
 
     @Test
     fun `should trigger KEY_PRESSED event with UP action`() {
-        val expectedActionCode = Action.UP.value
+        assertPressedAction(Action.UP, KeyEvent.ACTION_UP)
+    }
 
+    @Test
+    fun `should trigger KEY_PRESSED event for PAUSE button`() {
+        assertPressedKeyCodeEvent(Key.PAUSE, KeyEvent.KEYCODE_MEDIA_PAUSE)
+    }
+
+    @Test
+    fun `should trigger KEY_PRESSED event for STOP button`() {
+        assertPressedKeyCodeEvent(Key.STOP, KeyEvent.KEYCODE_MEDIA_STOP)
+    }
+
+    @Test
+    fun `should trigger KEY_PRESSED event for PLAY_PAUSE button`() {
+        assertPressedKeyCodeEvent(Key.PLAY_PAUSE, KeyEvent.KEYCODE_MEDIA_PLAY_PAUSE)
+    }
+
+    private fun assertPressedKeyCodeEvent(expectedKeyCode: Key, keyToHold: Int){
+        var keyCode: String? = null
+
+        core.on(Event.KEY_PRESSED.value) { bundle ->
+            bundle?.let { keyCode = it.getString(EventData.PRESSED_KEY_CODE.value) }
+        }
+
+        externalInputPlugin.holdKeyEvent(KeyEvent(-1, keyToHold))
+
+        assertEquals(expectedKeyCode.value, keyCode)
+    }
+
+    private fun assertPressedAction(expectedActionCode: Action, actionKey: Int){
         var actionCode: String? = null
 
         core.on(Event.KEY_PRESSED.value) { bundle ->
             bundle?.let { actionCode = it.getString(EventData.PRESSED_KEY_ACTION.value) }
         }
 
-        externalInputPlugin.holdKeyEvent(KeyEvent(KeyEvent.ACTION_UP, -1))
+        externalInputPlugin.holdKeyEvent(KeyEvent(actionKey, -1))
 
-        assertEquals(expectedActionCode, actionCode)
-    }
-
-    @Test
-    fun `should trigger KEY_PRESSED event for PAUSE button`() {
-        val expectedKeyCode = Key.PAUSE.value
-
-        var keyCode: String? = null
-
-        core.on(Event.KEY_PRESSED.value) { bundle ->
-            bundle?.let { keyCode = it.getString(EventData.PRESSED_KEY_CODE.value) }
-        }
-
-        externalInputPlugin.holdKeyEvent(KeyEvent(-1, KeyEvent.KEYCODE_MEDIA_PAUSE))
-
-        assertEquals(expectedKeyCode, keyCode)
-    }
-
-    @Test
-    fun `should trigger KEY_PRESSED event for STOP button`() {
-        val expectedKeyCode = Key.STOP.value
-
-        var keyCode: String? = null
-
-        core.on(Event.KEY_PRESSED.value) { bundle ->
-            bundle?.let { keyCode = it.getString(EventData.PRESSED_KEY_CODE.value) }
-        }
-
-        externalInputPlugin.holdKeyEvent(KeyEvent(-1, KeyEvent.KEYCODE_MEDIA_STOP))
-
-        assertEquals(expectedKeyCode, keyCode)
-    }
-
-    @Test
-    fun `should trigger KEY_PRESSED event for PLAY_PAUSE button`() {
-        val expectedKeyCode = Key.PLAY_PAUSE.value
-
-        var keyCode: String? = null
-
-        core.on(Event.KEY_PRESSED.value) { bundle ->
-            bundle?.let { keyCode = it.getString(EventData.PRESSED_KEY_CODE.value) }
-        }
-
-        externalInputPlugin.holdKeyEvent(KeyEvent(-1, KeyEvent.KEYCODE_MEDIA_PLAY_PAUSE))
-
-        assertEquals(expectedKeyCode, keyCode)
+        assertEquals(expectedActionCode.value, actionCode)
     }
 }

--- a/clappr/src/test/kotlin/io/clappr/player/plugin/ExternalInputPluginTest.kt
+++ b/clappr/src/test/kotlin/io/clappr/player/plugin/ExternalInputPluginTest.kt
@@ -23,6 +23,8 @@ class ExternalInputPluginTest {
 
     lateinit var externalInputPlugin: ExternalInputPlugin
 
+    private val anyIntegerValue = -1
+
     @Before
     fun setUp() {
         BaseObject.applicationContext = ApplicationProvider.getApplicationContext()
@@ -32,12 +34,10 @@ class ExternalInputPluginTest {
         externalInputPlugin = ExternalInputPlugin(core)
     }
 
-
     @Test
     fun `should trigger KEY_PRESSED event for PLAY button`() {
         assertPressedKeyCodeEvent(Key.PLAY, KeyEvent.KEYCODE_MEDIA_PLAY)
     }
-
 
     @Test
     fun `should trigger KEY_PRESSED event with DOWN action`() {
@@ -71,7 +71,7 @@ class ExternalInputPluginTest {
             bundle?.let { keyCode = it.getString(EventData.INPUT_KEY_CODE.value) }
         }
 
-        externalInputPlugin.holdKeyEvent(KeyEvent(-1, keyToHold))
+        externalInputPlugin.holdKeyEvent(KeyEvent(anyIntegerValue, keyToHold))
 
         assertEquals(expectedKeyCode.value, keyCode)
     }
@@ -83,7 +83,7 @@ class ExternalInputPluginTest {
             bundle?.let { actionCode = it.getString(EventData.INPUT_KEY_ACTION.value) }
         }
 
-        externalInputPlugin.holdKeyEvent(KeyEvent(actionKey, -1))
+        externalInputPlugin.holdKeyEvent(KeyEvent(actionKey, anyIntegerValue))
 
         assertEquals(expectedActionCode.value, actionCode)
     }

--- a/clappr/src/test/kotlin/io/clappr/player/plugin/ExternalInputPluginTest.kt
+++ b/clappr/src/test/kotlin/io/clappr/player/plugin/ExternalInputPluginTest.kt
@@ -23,7 +23,7 @@ class ExternalInputPluginTest {
 
     lateinit var externalInputPlugin: ExternalInputPlugin
 
-    private val anyIntegerValue = -1
+    private val anyKeyCode = -1
 
     @Before
     fun setUp() {
@@ -71,7 +71,7 @@ class ExternalInputPluginTest {
             bundle?.let { keyCode = it.getString(EventData.INPUT_KEY_CODE.value) }
         }
 
-        externalInputPlugin.holdKeyEvent(KeyEvent(anyIntegerValue, keyToHold))
+        externalInputPlugin.holdKeyEvent(KeyEvent(anyKeyCode, keyToHold))
 
         assertEquals(expectedKeyCode.value, keyCode)
     }
@@ -83,7 +83,7 @@ class ExternalInputPluginTest {
             bundle?.let { actionCode = it.getString(EventData.INPUT_KEY_ACTION.value) }
         }
 
-        externalInputPlugin.holdKeyEvent(KeyEvent(actionKey, anyIntegerValue))
+        externalInputPlugin.holdKeyEvent(KeyEvent(actionKey, anyKeyCode))
 
         assertEquals(expectedActionCode.value, actionCode)
     }

--- a/clappr/src/test/kotlin/io/clappr/player/plugin/ExternalInputPluginTest.kt
+++ b/clappr/src/test/kotlin/io/clappr/player/plugin/ExternalInputPluginTest.kt
@@ -1,0 +1,87 @@
+package io.clappr.player.plugin
+
+import android.view.KeyEvent
+import androidx.test.core.app.ApplicationProvider
+import io.clappr.player.base.BaseObject
+import io.clappr.player.base.Event
+import io.clappr.player.base.EventData
+import io.clappr.player.base.Options
+import io.clappr.player.base.keys.Action
+import io.clappr.player.base.keys.Key
+import io.clappr.player.components.Core
+import io.clappr.player.plugin.core.externalinput.ExternalInputPlugin
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import kotlin.test.assertEquals
+
+@RunWith(RobolectricTestRunner::class)
+class ExternalInputPluginTest {
+
+    lateinit var core: Core
+
+    lateinit var externalInputPlugin: ExternalInputPlugin
+
+    @Before
+    fun setUp() {
+        BaseObject.applicationContext = ApplicationProvider.getApplicationContext()
+
+        core = Core(Options())
+
+        externalInputPlugin = ExternalInputPlugin(core)
+    }
+
+
+    @Test
+    fun `should trigger KEY_PRESSED event for PLAY button`(){
+        val expectedKeyCode = Key.PLAY.value
+
+        var keyCode: String? = null
+
+        core.on(Event.KEY_PRESSED.value){ bundle ->
+            bundle?.let {
+                keyCode = it.getString(EventData.PRESSED_KEY_CODE.value)
+            }
+        }
+
+        externalInputPlugin.holdKeyEvent(-1, KeyEvent(-1, KeyEvent.KEYCODE_MEDIA_PLAY))
+
+        assertEquals(expectedKeyCode, keyCode)
+    }
+
+
+    @Test
+    fun `should trigger KEY_PRESSED event with DOWN action`(){
+        val expectedActionCode = Action.DOWN.value
+
+        var actionCode: String? = null
+
+        core.on(Event.KEY_PRESSED.value){ bundle ->
+            bundle?.let {
+                actionCode = it.getString(EventData.PRESSED_KEY_ACTION.value)
+            }
+        }
+
+        externalInputPlugin.holdKeyEvent(-1, KeyEvent(KeyEvent.ACTION_DOWN, -1))
+
+        assertEquals(expectedActionCode, actionCode)
+    }
+
+    @Test
+    fun `should trigger KEY_PRESSED event with UP action`(){
+        val expectedActionCode = Action.UP.value
+
+        var actionCode: String? = null
+
+        core.on(Event.KEY_PRESSED.value){ bundle ->
+            bundle?.let {
+                actionCode = it.getString(EventData.PRESSED_KEY_ACTION.value)
+            }
+        }
+
+        externalInputPlugin.holdKeyEvent(-1, KeyEvent(KeyEvent.ACTION_UP, -1))
+
+        assertEquals(expectedActionCode, actionCode)
+    }
+}

--- a/clappr/src/test/kotlin/io/clappr/player/plugin/ExternalInputPluginTest.kt
+++ b/clappr/src/test/kotlin/io/clappr/player/plugin/ExternalInputPluginTest.kt
@@ -93,4 +93,19 @@ class ExternalInputPluginTest {
 
         assertEquals(expectedKeyCode, keyCode)
     }
+
+    @Test
+    fun `should trigger KEY_PRESSED event for STOP button`() {
+        val expectedKeyCode = Key.STOP.value
+
+        var keyCode: String? = null
+
+        core.on(Event.KEY_PRESSED.value) { bundle ->
+            bundle?.let { keyCode = it.getString(EventData.PRESSED_KEY_CODE.value) }
+        }
+
+        externalInputPlugin.holdKeyEvent(KeyEvent(-1, KeyEvent.KEYCODE_MEDIA_STOP))
+
+        assertEquals(expectedKeyCode, keyCode)
+    }
 }

--- a/clappr/src/test/kotlin/io/clappr/player/plugin/ExternalInputPluginTest.kt
+++ b/clappr/src/test/kotlin/io/clappr/player/plugin/ExternalInputPluginTest.kt
@@ -43,7 +43,7 @@ class ExternalInputPluginTest {
             bundle?.let { keyCode = it.getString(EventData.PRESSED_KEY_CODE.value) }
         }
 
-        externalInputPlugin.holdKeyEvent(-1, KeyEvent(-1, KeyEvent.KEYCODE_MEDIA_PLAY))
+        externalInputPlugin.holdKeyEvent(KeyEvent(-1, KeyEvent.KEYCODE_MEDIA_PLAY))
 
         assertEquals(expectedKeyCode, keyCode)
     }
@@ -59,7 +59,7 @@ class ExternalInputPluginTest {
             bundle?.let { actionCode = it.getString(EventData.PRESSED_KEY_ACTION.value) }
         }
 
-        externalInputPlugin.holdKeyEvent(-1, KeyEvent(KeyEvent.ACTION_DOWN, -1))
+        externalInputPlugin.holdKeyEvent(KeyEvent(KeyEvent.ACTION_DOWN, -1))
 
         assertEquals(expectedActionCode, actionCode)
     }
@@ -74,7 +74,7 @@ class ExternalInputPluginTest {
             bundle?.let { actionCode = it.getString(EventData.PRESSED_KEY_ACTION.value) }
         }
 
-        externalInputPlugin.holdKeyEvent(-1, KeyEvent(KeyEvent.ACTION_UP, -1))
+        externalInputPlugin.holdKeyEvent(KeyEvent(KeyEvent.ACTION_UP, -1))
 
         assertEquals(expectedActionCode, actionCode)
     }
@@ -89,7 +89,7 @@ class ExternalInputPluginTest {
             bundle?.let { keyCode = it.getString(EventData.PRESSED_KEY_CODE.value) }
         }
 
-        externalInputPlugin.holdKeyEvent(-1, KeyEvent(-1, KeyEvent.KEYCODE_MEDIA_PAUSE))
+        externalInputPlugin.holdKeyEvent(KeyEvent(-1, KeyEvent.KEYCODE_MEDIA_PAUSE))
 
         assertEquals(expectedKeyCode, keyCode)
     }


### PR DESCRIPTION
Add external input devices support  such as TV's remote controls, Video Game Controls and others.
Initialy support `PLAY`, `PAUSE`, `STOP` and `PLAY_PAUSE` buttons.
