### PR TITLE
Destroy core from player

### DIFF
--- a/clappr/src/main/kotlin/io/clappr/player/Player.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/Player.kt
@@ -188,6 +188,10 @@ open class Player(private val base: BaseObject = BaseObject(),
         core = Core(options)
     }
 
+    protected fun destroyCore() {
+        core = null
+    }
+
     /**
      * Load a new media. Always make sure that the stop() method was called before invoking this
      *


### PR DESCRIPTION
### Goal

Add destroy method on player instance, so we can recreate core on configure call.

### How to test
1 - Run unit tests: `./gradlew clean test`