### PR TITLE
Handle Remote Control's Back Key

### DIFF
--- a/clappr/src/main/kotlin/io/clappr/player/Player.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/Player.kt
@@ -277,9 +277,7 @@ open class Player(private val base: BaseObject = BaseObject(),
     }
 
     private fun unbindPlaybackEvents() {
-        playbackEventsIds.forEach {
-            stopListening(it)
-        }
+        playbackEventsIds.forEach(::stopListening)
         playbackEventsIds.clear()
     }
 
@@ -290,9 +288,7 @@ open class Player(private val base: BaseObject = BaseObject(),
     }
 
     private fun unbindContainerEvents() {
-        containerEventsIds.forEach {
-            stopListening(it)
-        }
+        containerEventsIds.forEach(::stopListening)
         containerEventsIds.clear()
     }
 
@@ -303,9 +299,7 @@ open class Player(private val base: BaseObject = BaseObject(),
     }
 
     private fun unbindCoreEvents(){
-        coreEventsIds.forEach {
-            stopListening(it)
-        }
+        coreEventsIds.forEach(::stopListening)
         coreEventsIds.clear()
     }
 

--- a/clappr/src/main/kotlin/io/clappr/player/Player.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/Player.kt
@@ -21,10 +21,12 @@ import io.clappr.player.plugin.core.externalinput.ExternalInputPlugin
  *
  * Once instantiated it should be [configured][configure] and added to a view hierarchy before playback can begin.
  */
-open class Player(private val base: BaseObject = BaseObject(),
-                  private val coreEventsToListen: MutableSet<String> = mutableSetOf(),
-                  private val playbackEventsToListen: MutableSet<String> = mutableSetOf(),
-                  private val containerEventsToListen: MutableSet<String> = mutableSetOf()) : Fragment(), EventInterface by base {
+open class Player(
+    private val base: BaseObject = BaseObject(),
+    private val coreEventsToListen: MutableSet<String> = mutableSetOf(),
+    private val playbackEventsToListen: MutableSet<String> = mutableSetOf(),
+    private val containerEventsToListen: MutableSet<String> = mutableSetOf()
+) : Fragment(), EventInterface by base {
 
     companion object {
         init {
@@ -47,11 +49,12 @@ open class Player(private val base: BaseObject = BaseObject(),
     init {
         Event.values().forEach { playbackEventsToListen.add(it.value) }
         coreEventsToListen.addAll(
-                listOf(
-                        Event.REQUEST_FULLSCREEN.value,
-                        Event.EXIT_FULLSCREEN.value,
-                        Event.MEDIA_OPTIONS_SELECTED.value
-                ))
+            listOf(
+                Event.REQUEST_FULLSCREEN.value,
+                Event.EXIT_FULLSCREEN.value,
+                Event.MEDIA_OPTIONS_SELECTED.value
+            )
+        )
     }
 
     /**
@@ -101,11 +104,26 @@ open class Player(private val base: BaseObject = BaseObject(),
                 it.on(InternalEvent.DID_CHANGE_ACTIVE_PLAYBACK.value) { bindPlaybackEvents() }
                 it.on(InternalEvent.WILL_CHANGE_ACTIVE_CONTAINER.value) { unbindContainerEvents() }
                 it.on(InternalEvent.DID_CHANGE_ACTIVE_CONTAINER.value) { bindContainerEvents() }
-                it.on(Event.REQUEST_FULLSCREEN.value) { bundle: Bundle? -> trigger(Event.REQUEST_FULLSCREEN.value, bundle) }
+                it.on(Event.REQUEST_FULLSCREEN.value) { bundle: Bundle? ->
+                    trigger(
+                        Event.REQUEST_FULLSCREEN.value,
+                        bundle
+                    )
+                }
                 it.on(Event.EXIT_FULLSCREEN.value) { bundle: Bundle? -> trigger(Event.EXIT_FULLSCREEN.value, bundle) }
-                it.on(Event.MEDIA_OPTIONS_SELECTED.value) { bundle: Bundle? -> trigger(Event.MEDIA_OPTIONS_SELECTED.value, bundle) }
+                it.on(Event.MEDIA_OPTIONS_SELECTED.value) { bundle: Bundle? ->
+                    trigger(
+                        Event.MEDIA_OPTIONS_SELECTED.value,
+                        bundle
+                    )
+                }
                 it.on(Event.DID_SELECT_AUDIO.value) { bundle: Bundle? -> trigger(Event.DID_SELECT_AUDIO.value, bundle) }
-                it.on(Event.DID_SELECT_SUBTITLE.value) { bundle: Bundle? -> trigger(Event.DID_SELECT_SUBTITLE.value, bundle) }
+                it.on(Event.DID_SELECT_SUBTITLE.value) { bundle: Bundle? ->
+                    trigger(
+                        Event.DID_SELECT_SUBTITLE.value,
+                        bundle
+                    )
+                }
 
                 if (it.activeContainer != null) {
                     bindContainerEvents()
@@ -272,7 +290,14 @@ open class Player(private val base: BaseObject = BaseObject(),
 
     private fun bindPlaybackEvents() {
         core?.activePlayback?.let {
-            playbackEventsToListen.mapTo(playbackEventsIds) { event -> listenTo(it, event) { bundle: Bundle? -> trigger(event, bundle) } }
+            playbackEventsToListen.mapTo(playbackEventsIds) { event ->
+                listenTo(it, event) { bundle: Bundle? ->
+                    trigger(
+                        event,
+                        bundle
+                    )
+                }
+            }
         }
     }
 
@@ -283,7 +308,12 @@ open class Player(private val base: BaseObject = BaseObject(),
 
     private fun bindContainerEvents() {
         core?.activeContainer?.let {
-            containerEventsToListen.mapTo(containerEventsIds) { event -> listenTo(it, event) { bundle: Bundle? -> trigger(event, bundle) } }
+            containerEventsToListen.mapTo(containerEventsIds) { event ->
+                listenTo(
+                    it,
+                    event
+                ) { bundle: Bundle? -> trigger(event, bundle) }
+            }
         }
     }
 
@@ -292,13 +322,20 @@ open class Player(private val base: BaseObject = BaseObject(),
         containerEventsIds.clear()
     }
 
-    private fun bindCoreEvents(){
+    private fun bindCoreEvents() {
         core?.let {
-            coreEventsToListen.mapTo(coreEventsIds) { event -> listenTo(it, event) { bundle: Bundle? -> trigger(event, bundle) } }
+            coreEventsToListen.mapTo(coreEventsIds) { event ->
+                listenTo(it, event) { bundle: Bundle? ->
+                    trigger(
+                        event,
+                        bundle
+                    )
+                }
+            }
         }
     }
 
-    private fun unbindCoreEvents(){
+    private fun unbindCoreEvents() {
         coreEventsIds.forEach(::stopListening)
         coreEventsIds.clear()
     }

--- a/clappr/src/main/kotlin/io/clappr/player/base/keys/Key.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/base/keys/Key.kt
@@ -9,7 +9,8 @@ enum class Key(val value: String) {
     UP("up"),
     DOWN("down"),
     RIGHT("right"),
-    LEFT("left");
+    LEFT("left"),
+    BACK("back");
 
     companion object {
         fun getByValue(value: String) = values().firstOrNull { it.value == value }

--- a/clappr/src/main/kotlin/io/clappr/player/plugin/control/MediaControl.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/plugin/control/MediaControl.kt
@@ -266,7 +266,7 @@ open class MediaControl(core: Core, pluginName: String = name) : UICorePlugin(co
         lastInteractionTime = SystemClock.elapsedRealtime()
     }
 
-    private fun toggleVisibility() {
+    protected fun toggleVisibility() {
         if (isEnabled) {
             if (isVisible) {
                 hide()

--- a/clappr/src/main/kotlin/io/clappr/player/plugin/control/MediaControl.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/plugin/control/MediaControl.kt
@@ -62,6 +62,7 @@ open class MediaControl(core: Core, pluginName: String = name) : UICorePlugin(co
     }
 
     open val invalidActivationKeys = listOf(Key.UNDEFINED)
+    private val navigationKeys = listOf(Key.UP, Key.DOWN, Key.LEFT, Key.RIGHT)
 
     private val backgroundView: View by lazy { view.findViewById(R.id.background_view) as View }
 
@@ -306,13 +307,19 @@ open class MediaControl(core: Core, pluginName: String = name) : UICorePlugin(co
         bundle?.let {
             val keyCode = it.getString(EventData.INPUT_KEY_CODE.value) ?: ""
             val keyAction = it.getString(EventData.INPUT_KEY_ACTION.value) ?: ""
-            val isValidActivationKey =
-                invalidActivationKeys.contains(Key.getByValue(keyCode)).not()
+            val key = Key.getByValue(keyCode) ?: Key.UNDEFINED
+            val action = Action.getByValue(keyAction)
 
-            if (isValidActivationKey && Action.getByValue(keyAction) == Action.UP)
-                toggleVisibility()
+            if (isValidActivationKey(key) && action == Action.UP) {
+                when (isVisible) {
+                    true -> if (navigationKeys.contains(key)) updateInteractionTime()
+                    else -> if (isValidActivationKey(key)) toggleVisibility()
+                }
+            }
         }
     }
+
+    private fun isValidActivationKey(key: Key) = invalidActivationKeys.contains(key).not()
 
     private fun stopContainerListeners() {
         containerListenerIds.forEach(::stopListening)

--- a/clappr/src/main/kotlin/io/clappr/player/plugin/control/MediaControl.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/plugin/control/MediaControl.kt
@@ -306,10 +306,10 @@ open class MediaControl(core: Core, pluginName: String = name) : UICorePlugin(co
         bundle?.let {
             val keyCode = it.getString(EventData.INPUT_KEY_CODE.value) ?: ""
             val keyAction = it.getString(EventData.INPUT_KEY_ACTION.value) ?: ""
-            val isKeyAllowedToShownMediaControl =
+            val isKeyAllowedToShowMediaControl =
                 keysThatMediaControlWillNotBeShown.contains(Key.getByValue(keyCode)).not()
 
-            if (isKeyAllowedToShownMediaControl && Action.getByValue(keyAction) == Action.UP)
+            if (isKeyAllowedToShowMediaControl && Action.getByValue(keyAction) == Action.UP)
                 toggleVisibility()
         }
     }

--- a/clappr/src/main/kotlin/io/clappr/player/plugin/control/MediaControl.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/plugin/control/MediaControl.kt
@@ -104,7 +104,7 @@ open class MediaControl(core: Core, pluginName: String = name) : UICorePlugin(co
     protected val isVisible: Boolean
         get() = visibility == Visibility.VISIBLE
 
-    val isPlaybackIdle: Boolean
+    private val isPlaybackIdle: Boolean
         get() {
             return core.activePlayback?.state == Playback.State.IDLE ||
                     core.activePlayback?.state == Playback.State.NONE

--- a/clappr/src/main/kotlin/io/clappr/player/plugin/control/MediaControl.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/plugin/control/MediaControl.kt
@@ -57,6 +57,8 @@ open class MediaControl(core: Core, pluginName: String = name) : UICorePlugin(co
 
     private var lastInteractionTime = 0L
 
+    var hideAnimationEnded = false
+
     override val view by lazy {
         LayoutInflater.from(applicationContext).inflate(R.layout.media_control, null) as FrameLayout
     }
@@ -102,7 +104,7 @@ open class MediaControl(core: Core, pluginName: String = name) : UICorePlugin(co
     protected val isVisible: Boolean
         get() = visibility == Visibility.VISIBLE
 
-    private val isPlaybackIdle: Boolean
+    val isPlaybackIdle: Boolean
         get() {
             return core.activePlayback?.state == Playback.State.IDLE ||
                     core.activePlayback?.state == Playback.State.NONE
@@ -360,6 +362,8 @@ open class MediaControl(core: Core, pluginName: String = name) : UICorePlugin(co
     }
 
     override fun hide() {
+        hideAnimationEnded = false
+
         if (isEnabled && isPlaybackIdle) return
 
         core.trigger(InternalEvent.WILL_HIDE_MEDIA_CONTROL.value)
@@ -368,6 +372,7 @@ open class MediaControl(core: Core, pluginName: String = name) : UICorePlugin(co
             hideMediaControlElements()
             hideDefaultMediaControlPanels()
             hideModalPanel()
+            hideAnimationEnded = true
 
             core.trigger(InternalEvent.DID_HIDE_MEDIA_CONTROL.value)
         }

--- a/clappr/src/main/kotlin/io/clappr/player/plugin/control/MediaControl.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/plugin/control/MediaControl.kt
@@ -98,7 +98,7 @@ open class MediaControl(core: Core, pluginName: String = name) : UICorePlugin(co
     val isEnabled: Boolean
         get() = state == State.ENABLED
 
-    val isVisible: Boolean
+    protected val isVisible: Boolean
         get() = visibility == Visibility.VISIBLE
 
     private val isPlaybackIdle: Boolean
@@ -262,7 +262,7 @@ open class MediaControl(core: Core, pluginName: String = name) : UICorePlugin(co
         }, duration)
     }
 
-    fun updateInteractionTime() {
+    protected fun updateInteractionTime() {
         lastInteractionTime = SystemClock.elapsedRealtime()
     }
 

--- a/clappr/src/main/kotlin/io/clappr/player/plugin/control/MediaControl.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/plugin/control/MediaControl.kt
@@ -61,7 +61,7 @@ open class MediaControl(core: Core, pluginName: String = name) : UICorePlugin(co
         LayoutInflater.from(applicationContext).inflate(R.layout.media_control, null) as FrameLayout
     }
 
-    open val keysThatMediaControlWillNotBeShown = listOf(Key.UNDEFINED)
+    open val invalidActivationKeys = listOf(Key.UNDEFINED)
 
     private val backgroundView: View by lazy { view.findViewById(R.id.background_view) as View }
 
@@ -306,10 +306,10 @@ open class MediaControl(core: Core, pluginName: String = name) : UICorePlugin(co
         bundle?.let {
             val keyCode = it.getString(EventData.INPUT_KEY_CODE.value) ?: ""
             val keyAction = it.getString(EventData.INPUT_KEY_ACTION.value) ?: ""
-            val isKeyAllowedToShowMediaControl =
-                keysThatMediaControlWillNotBeShown.contains(Key.getByValue(keyCode)).not()
+            val isValidActivationKey =
+                invalidActivationKeys.contains(Key.getByValue(keyCode)).not()
 
-            if (isKeyAllowedToShowMediaControl && Action.getByValue(keyAction) == Action.UP)
+            if (isValidActivationKey && Action.getByValue(keyAction) == Action.UP)
                 toggleVisibility()
         }
     }

--- a/clappr/src/main/kotlin/io/clappr/player/plugin/control/MediaControl.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/plugin/control/MediaControl.kt
@@ -98,7 +98,7 @@ open class MediaControl(core: Core, pluginName: String = name) : UICorePlugin(co
     val isEnabled: Boolean
         get() = state == State.ENABLED
 
-    private val isVisible: Boolean
+    val isVisible: Boolean
         get() = visibility == Visibility.VISIBLE
 
     private val isPlaybackIdle: Boolean

--- a/clappr/src/main/kotlin/io/clappr/player/plugin/control/MediaControl.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/plugin/control/MediaControl.kt
@@ -262,7 +262,7 @@ open class MediaControl(core: Core, pluginName: String = name) : UICorePlugin(co
         }, duration)
     }
 
-    private fun updateInteractionTime() {
+    fun updateInteractionTime() {
         lastInteractionTime = SystemClock.elapsedRealtime()
     }
 

--- a/clappr/src/main/kotlin/io/clappr/player/plugin/core/externalinput/ExternalInputPlugin.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/plugin/core/externalinput/ExternalInputPlugin.kt
@@ -26,7 +26,8 @@ class ExternalInputPlugin(core: Core) : CorePlugin(core, name = name), ExternalI
             KeyEvent.KEYCODE_DPAD_UP to Key.UP.value,
             KeyEvent.KEYCODE_DPAD_DOWN to Key.DOWN.value,
             KeyEvent.KEYCODE_DPAD_RIGHT to Key.RIGHT.value,
-            KeyEvent.KEYCODE_DPAD_LEFT to Key.LEFT.value)
+            KeyEvent.KEYCODE_DPAD_LEFT to Key.LEFT.value,
+            KeyEvent.KEYCODE_BACK to Key.BACK.value)
     
     override fun holdKeyEvent(event: KeyEvent) {
         core.trigger(Event.DID_RECEIVE_INPUT_KEY.value, Bundle().apply {

--- a/clappr/src/test/kotlin/io/clappr/player/plugin/ExternalInputPluginTest.kt
+++ b/clappr/src/test/kotlin/io/clappr/player/plugin/ExternalInputPluginTest.kt
@@ -84,6 +84,11 @@ class ExternalInputPluginTest {
         assertPressedKeyCodeEvent(Key.RIGHT, KeyEvent.KEYCODE_DPAD_RIGHT)
     }
 
+    @Test
+    fun `should trigger KEY_PRESSED event for BACK button`() {
+        assertPressedKeyCodeEvent(Key.BACK, KeyEvent.KEYCODE_BACK)
+    }
+
     private fun assertPressedKeyCodeEvent(expectedKeyCode: Key, keyToHold: Int){
         var keyCode: String? = null
 


### PR DESCRIPTION
## Goal
Add support for remote control's back key and add core events list to Player's constructor following same pattern used for playback and container events.

## How to test
- Run unit tests: `./gradlew clean test`