### PR TITLE
Remove media options

### DIFF
--- a/clappr/src/main/kotlin/io/clappr/player/Player.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/Player.kt
@@ -93,7 +93,8 @@ open class Player(private val base: BaseObject = BaseObject(),
                 it.on(InternalEvent.DID_CHANGE_ACTIVE_CONTAINER.value) { bindContainerEvents() }
                 it.on(Event.REQUEST_FULLSCREEN.value) { bundle: Bundle? -> trigger(Event.REQUEST_FULLSCREEN.value, bundle) }
                 it.on(Event.EXIT_FULLSCREEN.value) { bundle: Bundle? -> trigger(Event.EXIT_FULLSCREEN.value, bundle) }
-                it.on(Event.MEDIA_OPTIONS_SELECTED.value) { bundle: Bundle? -> trigger(Event.MEDIA_OPTIONS_SELECTED.value, bundle) }
+                it.on(Event.DID_SELECT_AUDIO.value) { bundle: Bundle? -> trigger(Event.DID_SELECT_AUDIO.value, bundle) }
+                it.on(Event.DID_SELECT_SUBTITLE.value) { bundle: Bundle? -> trigger(Event.DID_SELECT_SUBTITLE.value, bundle) }
 
                 if (it.activeContainer != null) {
                     bindContainerEvents()

--- a/clappr/src/main/kotlin/io/clappr/player/Player.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/Player.kt
@@ -93,6 +93,7 @@ open class Player(private val base: BaseObject = BaseObject(),
                 it.on(InternalEvent.DID_CHANGE_ACTIVE_CONTAINER.value) { bindContainerEvents() }
                 it.on(Event.REQUEST_FULLSCREEN.value) { bundle: Bundle? -> trigger(Event.REQUEST_FULLSCREEN.value, bundle) }
                 it.on(Event.EXIT_FULLSCREEN.value) { bundle: Bundle? -> trigger(Event.EXIT_FULLSCREEN.value, bundle) }
+                it.on(Event.MEDIA_OPTIONS_SELECTED.value) { bundle: Bundle? -> trigger(Event.MEDIA_OPTIONS_SELECTED.value, bundle) }
                 it.on(Event.DID_SELECT_AUDIO.value) { bundle: Bundle? -> trigger(Event.DID_SELECT_AUDIO.value, bundle) }
                 it.on(Event.DID_SELECT_SUBTITLE.value) { bundle: Bundle? -> trigger(Event.DID_SELECT_SUBTITLE.value, bundle) }
 

--- a/clappr/src/main/kotlin/io/clappr/player/base/Events.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/base/Events.kt
@@ -200,6 +200,24 @@ enum class EventData(val value: String) {
     SELECTED_SUBTITLE("selectedSubtitle"),
 
     /**
+     * [Event.DID_UPDATE_AUDIO] data
+     *
+     * Type: String
+     *
+     * Updated audio language
+     */
+    UPDATED_AUDIO("updatedAudio"),
+
+    /**
+     * [Event.DID_UPDATE_SUBTITLE] data
+     *
+     * Type: String
+     *
+     * Updated subtitle language
+     */
+    UPDATED_SUBTITLE("updatedSubtitle"),
+
+    /**
      * [Event.DID_UPDATE_BITRATE] data
      *
      * Type: Long

--- a/clappr/src/main/kotlin/io/clappr/player/base/Events.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/base/Events.kt
@@ -178,6 +178,7 @@ enum class EventData(val value: String) {
      *
      * Selected media options.
      */
+    @Deprecated("EventData.SELECTED_AUDIO and EventData.SELECTED_SUBTITLE should be used instead.")
     MEDIA_OPTIONS_SELECTED_RESPONSE("mediaOptionsSelectedResponse"),
 
     /**

--- a/clappr/src/main/kotlin/io/clappr/player/base/Events.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/base/Events.kt
@@ -101,25 +101,26 @@ enum class Event(val value: String) {
     DID_UPDATE_POSTER("didUpdatePoster"),
 
     /**
-     * Media Options Selected. Triggered when the user select a Media Option.
-     * Data provided with the [EventData.MEDIA_OPTIONS_SELECTED_RESPONSE] key.
-     */
-    MEDIA_OPTIONS_SELECTED("mediaOptionsSelected"),
-
-    /**
-     * Media Options Update. Triggered when the Playback load a media option
-     */
-    MEDIA_OPTIONS_UPDATE("mediaOptionsUpdate"),
-
-    /**
-     * Triggered when an audio is selected
+     * Triggered when an audio is selected.
+     * Data provided with the [EventData.SELECTED_AUDIO] key.
      */
     DID_SELECT_AUDIO("didSelectAudio"),
 
     /**
-     * Triggered when a subtitle is selected
+     * Triggered when a subtitle is selected.
+     * Data provided with the [EventData.SELECTED_SUBTITLE] key.
      */
     DID_SELECT_SUBTITLE("didSelectSubtitle"),
+
+    /**
+     * Triggered when an audio is updated
+     */
+    DID_UPDATE_AUDIO("didUpdateAudio"),
+
+    /**
+     * Triggered when a subtitle is updated
+     */
+    DID_UPDATE_SUBTITLE("didUpdateSubtitle"),
 
     /**
      * There was a change in DVR status
@@ -158,13 +159,22 @@ enum class Event(val value: String) {
 @Keep
 enum class EventData(val value: String) {
     /**
-     * [Event.MEDIA_OPTIONS_SELECTED] data
+     * [Event.DID_SELECT_AUDIO] data
      *
      * Type: String
      *
-     * Selected media options.
+     * Selected audio language
      */
-    MEDIA_OPTIONS_SELECTED_RESPONSE("mediaOptionsSelectedResponse"),
+    SELECTED_AUDIO("selectedAudio"),
+
+    /**
+     * [Event.DID_SELECT_SUBTITLE] data
+     *
+     * Type: String
+     *
+     * Selected subtitle language
+     */
+    SELECTED_SUBTITLE("selectedSubtitle"),
 
     /**
      * [Event.DID_UPDATE_BITRATE] data

--- a/clappr/src/main/kotlin/io/clappr/player/base/Events.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/base/Events.kt
@@ -101,6 +101,19 @@ enum class Event(val value: String) {
     DID_UPDATE_POSTER("didUpdatePoster"),
 
     /**
+     * Media Options Selected. Triggered when the user select a Media Option.
+     * Data provided with the [EventData.MEDIA_OPTIONS_SELECTED_RESPONSE] key.
+     */
+    @Deprecated("Event.DID_SELECT_AUDIO and Event.DID_SELECT_SUBTITLE should be used instead.")
+    MEDIA_OPTIONS_SELECTED("mediaOptionsSelected"),
+
+    /**
+     * Media Options Update. Triggered when the Playback load a media option
+     */
+    @Deprecated("Event.DID_UPDATE_AUDIO and Event.DID_UPDATE_SUBTITLE should be used instead.")
+    MEDIA_OPTIONS_UPDATE("mediaOptionsUpdate"),
+
+    /**
      * Triggered when an audio is selected.
      * Data provided with the [EventData.SELECTED_AUDIO] key.
      */
@@ -158,6 +171,15 @@ enum class Event(val value: String) {
  */
 @Keep
 enum class EventData(val value: String) {
+    /**
+     * [Event.MEDIA_OPTIONS_SELECTED] data
+     *
+     * Type: String
+     *
+     * Selected media options.
+     */
+    MEDIA_OPTIONS_SELECTED_RESPONSE("mediaOptionsSelectedResponse"),
+
     /**
      * [Event.DID_SELECT_AUDIO] data
      *

--- a/clappr/src/main/kotlin/io/clappr/player/base/InternalEvents.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/base/InternalEvents.kt
@@ -45,5 +45,7 @@ enum class InternalEventData(val value: String) {
     HEIGHT("height"),
     WIDTH("width"),
     TOUCH_X_AXIS("touchXAxis"),
-    TOUCH_Y_AXIS("touchYAxis")
+    TOUCH_Y_AXIS("touchYAxis"),
+    FOUND_AUDIOS("foundAudios"),
+    FOUND_SUBTITLES("foundSubtitles")
 }

--- a/clappr/src/main/kotlin/io/clappr/player/base/InternalEvents.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/base/InternalEvents.kt
@@ -16,7 +16,6 @@ enum class InternalEvent (val value: String) {
     DID_NOT_LOAD_SOURCE("didNotLoadSource"),
     WILL_DESTROY("willDestroy"),
     DID_DESTROY("didDestroy"),
-    MEDIA_OPTIONS_READY("mediaOptionsReady"),
     DID_FIND_AUDIO("didFindAudio"),
     DID_FIND_SUBTITLE("didFindSubtitle"),
     DID_UPDATE_OPTIONS("didUpdateOptions"),

--- a/clappr/src/main/kotlin/io/clappr/player/base/Options.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/base/Options.kt
@@ -25,11 +25,6 @@ enum class ClapprOption(val value: String) {
      */
     SUBTITLES("subtitles"),
     /**
-     * String List to selected MediaOptions.
-     */
-    @Deprecated("This option is deprecated and can be changed in the near future.", level = DeprecationLevel.WARNING)
-    SELECTED_MEDIA_OPTIONS("selectedMediaOptions"),
-    /**
      * Byte Array of drm licenses
      */
     DRM_LICENSES("drmLicenses"),

--- a/clappr/src/main/kotlin/io/clappr/player/base/Options.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/base/Options.kt
@@ -3,9 +3,10 @@ package io.clappr.player.base
 import java.util.*
 
 class Options(
-        var source: String? = null,
-        var mimeType: String? = null,
-        val options: HashMap<String, Any> = hashMapOf<String, Any>()) : MutableMap<String, Any> by options
+    var source: String? = null,
+    var mimeType: String? = null,
+    val options: HashMap<String, Any> = hashMapOf()
+) : MutableMap<String, Any> by options
 
 enum class ClapprOption(val value: String) {
     /**
@@ -45,12 +46,15 @@ enum class ClapprOption(val value: String) {
      * Boolean value indicating if Audio Focus should be handled by Clappr. Default value is false.
      */
     HANDLE_AUDIO_FOCUS("handleAudioFocus"),
-
+    /**
+     * String List to selected MediaOptions.
+     */
+    @Deprecated("ClapprOption.DEFAULT_AUDIO and ClapprOption.DEFAULT_SUBTITLE should be used instead.")
+    SELECTED_MEDIA_OPTIONS("selectedMediaOptions"),
     /**
      * String that represents default audio
      */
     DEFAULT_AUDIO("defaultAudio"),
-
     /**
      * String that represents default subtitle
      */

--- a/clappr/src/main/kotlin/io/clappr/player/components/MediaOption.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/components/MediaOption.kt
@@ -1,7 +1,6 @@
 package io.clappr.player.components
 
 enum class AudioLanguage(val value: String) {
-    UNSET(""),
     ORIGINAL("und"),
     PORTUGUESE("por"),
     ENGLISH("eng")

--- a/clappr/src/main/kotlin/io/clappr/player/components/MediaOption.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/components/MediaOption.kt
@@ -10,3 +10,9 @@ enum class SubtitleLanguage(val value: String) {
     OFF("off"),
     PORTUGUESE("por")
 }
+
+@Deprecated("ClapprOption.DEFAULT_AUDIO and ClapprOption.DEFAULT_SUBTITLE should be used instead.")
+fun buildMediaOptionsJson(selectedSubtitle: String, selectedAudio: String?) = when (selectedAudio) {
+    null -> """{"media_option":[{"name":"$selectedSubtitle","type":"SUBTITLE"}]}}"""
+    else -> """{"media_option":[{"name":"$selectedSubtitle","type":"SUBTITLE"},{"name":"$selectedAudio","type":"AUDIO"}]}}"""
+}

--- a/clappr/src/main/kotlin/io/clappr/player/components/MediaOption.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/components/MediaOption.kt
@@ -1,8 +1,8 @@
 package io.clappr.player.components
 
-data class MediaOption(val name: String, val type: MediaOptionType, val raw: Any?, val info: Map<String, Any>?)
+data class MediaOption(val name: String, val type: MediaOptionType)
 
-val SUBTITLE_OFF = MediaOption(SubtitleLanguage.OFF.value, MediaOptionType.SUBTITLE, null, null)
+val SUBTITLE_OFF = MediaOption(SubtitleLanguage.OFF.value, MediaOptionType.SUBTITLE)
 
 enum class AudioLanguage(val value: String) {
     ORIGINAL("und"),

--- a/clappr/src/main/kotlin/io/clappr/player/components/MediaOption.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/components/MediaOption.kt
@@ -12,7 +12,7 @@ enum class SubtitleLanguage(val value: String) {
 }
 
 @Deprecated("ClapprOption.DEFAULT_AUDIO and ClapprOption.DEFAULT_SUBTITLE should be used instead.")
-fun buildMediaOptionsJson(selectedSubtitle: String, selectedAudio: String?) = when (selectedAudio) {
+fun Playback.buildMediaOptionsJson() = when (selectedAudio) {
     null -> """{"media_option":[{"name":"$selectedSubtitle","type":"SUBTITLE"}]}}"""
     else -> """{"media_option":[{"name":"$selectedSubtitle","type":"SUBTITLE"},{"name":"$selectedAudio","type":"AUDIO"}]}}"""
 }

--- a/clappr/src/main/kotlin/io/clappr/player/components/MediaOption.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/components/MediaOption.kt
@@ -1,10 +1,7 @@
 package io.clappr.player.components
 
-data class MediaOption(val name: String, val type: MediaOptionType)
-
-val SUBTITLE_OFF = MediaOption(SubtitleLanguage.OFF.value, MediaOptionType.SUBTITLE)
-
 enum class AudioLanguage(val value: String) {
+    UNSET(""),
     ORIGINAL("und"),
     PORTUGUESE("por"),
     ENGLISH("eng")
@@ -13,9 +10,4 @@ enum class AudioLanguage(val value: String) {
 enum class SubtitleLanguage(val value: String) {
     OFF("off"),
     PORTUGUESE("por")
-}
-
-enum class MediaOptionType {
-    SUBTITLE,
-    AUDIO;
 }

--- a/clappr/src/main/kotlin/io/clappr/player/components/Playback.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/components/Playback.kt
@@ -175,8 +175,13 @@ abstract class Playback(
         get() = options[DEFAULT_SUBTITLE.value] as? String
 
     fun setupInitialMediasFromClapprOptions() {
-        defaultAudio?.takeIf { it.toLowerCase() in availableAudios }?.let { selectedAudio = it }
-        defaultSubtitle?.takeIf { it.toLowerCase() in availableSubtitles }?.let { selectedSubtitle = it }
+        defaultAudio?.toLowerCase()
+            .takeIf { it in availableAudios }
+            ?.let { selectedAudio = it }
+
+        defaultSubtitle?.toLowerCase()
+            .takeIf { it in availableSubtitles }
+            ?.let { selectedSubtitle = it }
     }
 
     private fun configureStartAt() {

--- a/clappr/src/main/kotlin/io/clappr/player/components/Playback.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/components/Playback.kt
@@ -52,8 +52,30 @@ abstract class Playback(
             trigger(DID_UPDATE_OPTIONS.value)
         }
 
+    val availableAudios = mutableListOf<String>()
+
+    val availableSubtitles = mutableListOf<String>()
+
+    var selectedAudio = ""
+        set(value) {
+            if (value !in availableAudios) return
+
+            changeAudioTrack(value)
+
+            field = value
+            trigger(DID_SELECT_AUDIO.value)
+        }
+
+    var selectedSubtitle = "off"
+
+    open fun changeAudioTrack(name: String) {}
+
+    @Deprecated("")
     var selectedMediaOptionList = ArrayList<MediaOption>()
         private set
+
+    @Deprecated("")
+    protected var mediaOptionList = LinkedList<MediaOption>()
 
     open val mediaType: MediaType
         get() = UNKNOWN
@@ -103,8 +125,6 @@ abstract class Playback(
      * PS.: If you set a volume greater than 1.0f we'll set the volume to 1.0f
      */
     open var volume: Float? = null
-
-    protected var mediaOptionList = LinkedList<MediaOption>()
 
     private val audioKeys = mapOf(
         ORIGINAL.value to listOf("original", "und"),

--- a/clappr/src/main/kotlin/io/clappr/player/components/Playback.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/components/Playback.kt
@@ -1,7 +1,9 @@
 package io.clappr.player.components
 
+import android.os.Bundle
 import io.clappr.player.base.ClapprOption.*
 import io.clappr.player.base.Event.*
+import io.clappr.player.base.EventData
 import io.clappr.player.base.InternalEvent.DID_UPDATE_OPTIONS
 import io.clappr.player.base.NamedType
 import io.clappr.player.base.Options
@@ -111,7 +113,8 @@ abstract class Playback(
             require(value in availableAudios) { "Audio not available" }
 
             internalSelectedAudio = value
-            trigger(DID_UPDATE_AUDIO.value)
+            val data = Bundle().apply { putString(EventData.UPDATED_AUDIO.value, value) }
+            trigger(DID_UPDATE_AUDIO.value, data)
             trigger(MEDIA_OPTIONS_UPDATE.value)
         }
         get() = internalSelectedAudio
@@ -125,7 +128,8 @@ abstract class Playback(
             require(value in availableSubtitles) { "Subtitle not available" }
 
             internalSelectedSubtitle = value
-            trigger(DID_UPDATE_SUBTITLE.value)
+            val data = Bundle().apply { putString(EventData.UPDATED_SUBTITLE.value, value) }
+            trigger(DID_UPDATE_SUBTITLE.value, data)
             trigger(MEDIA_OPTIONS_UPDATE.value)
         }
         get() = internalSelectedSubtitle

--- a/clappr/src/main/kotlin/io/clappr/player/components/Playback.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/components/Playback.kt
@@ -99,8 +99,8 @@ abstract class Playback(
 
     val availableSubtitles = mutableSetOf<String>()
 
-    protected var internalSelectedAudio = AudioLanguage.UNSET.value
-    open var selectedAudio: String
+    protected var internalSelectedAudio: String? = null
+    open var selectedAudio: String?
         /**
          * @throws IllegalArgumentException when audio is not available
          */

--- a/clappr/src/main/kotlin/io/clappr/player/playback/ExoPlayerExtensions.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/playback/ExoPlayerExtensions.kt
@@ -8,12 +8,12 @@ import io.clappr.player.components.AudioLanguage
 import io.clappr.player.components.SubtitleLanguage
 import java.util.*
 
-fun Player.getSelectedAudio(trackSelector: MappingTrackSelector): String {
+fun Player.getSelectedAudio(trackSelector: MappingTrackSelector): String? {
     val rendererIndex = trackSelector.audioTracks().firstOrNull()?.rendererIndex
-        ?: return AudioLanguage.UNSET.value
+        ?: return null
 
     val selectedFormat = currentTrackSelections.get(rendererIndex)?.selectedFormat
-        ?: return AudioLanguage.UNSET.value
+        ?: return null
 
     return selectedFormat.language.toStandardAudioLanguage()
 }

--- a/clappr/src/main/kotlin/io/clappr/player/playback/ExoPlayerExtensions.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/playback/ExoPlayerExtensions.kt
@@ -8,27 +8,27 @@ import io.clappr.player.components.AudioLanguage
 import io.clappr.player.components.SubtitleLanguage
 import java.util.*
 
-private val audioStandardMap = mapOf(
-    AudioLanguage.ORIGINAL.value to listOf("original", "und"),
-    AudioLanguage.PORTUGUESE.value to listOf("pt", "por"),
-    AudioLanguage.ENGLISH.value to listOf("en", "eng")
-)
+fun Player.getSelectedAudio(trackSelector: MappingTrackSelector): String {
+    val rendererIndex = trackSelector.audioTracks()
+        .firstOrNull()?.rendererIndex ?: return AudioLanguage.UNSET.value
 
-private val subtitleStandardMap = mapOf(
-    SubtitleLanguage.OFF.value to listOf("", "off"),
-    SubtitleLanguage.PORTUGUESE.value to listOf("pt", "por")
-)
+    val selectedFormat = currentTrackSelections.get(rendererIndex)?.selectedFormat
+        ?: return AudioLanguage.UNSET.value
 
-val Player.selectedAudio: String
-    get() {
-        val selectedFormat = currentTrackSelections.get(TRACK_TYPE_AUDIO)?.selectedFormat
-            ?: return AudioLanguage.UNSET.value
+    return selectedFormat.language.toStandardAudioLanguage()
+}
 
-        return selectedFormat.language.toStandardAudioLanguage()
-    }
+fun Player.getSelectedSubtitle(trackSelector: MappingTrackSelector): String {
+    val rendererIndex = trackSelector.subtitleTracks()
+        .firstOrNull()?.rendererIndex ?: return SubtitleLanguage.OFF.value
 
-val Player.selectedSubtitle: String
-    get() = currentTrackSelections.get(TRACK_TYPE_TEXT)?.selectedFormat?.language.toStandardSubtitleLanguage()
+    return currentTrackSelections.get(rendererIndex)
+        ?.selectedFormat?.language.toStandardSubtitleLanguage()
+}
+
+fun MappingTrackSelector.audioTracks() = tracks().filter { it.rendererType == TRACK_TYPE_AUDIO }
+
+fun MappingTrackSelector.subtitleTracks() = tracks().filter { it.rendererType == TRACK_TYPE_TEXT }
 
 private fun MappingTrackSelector.tracks(): List<TrackInfo> {
 
@@ -69,10 +69,6 @@ private fun MappingTrackSelector.tracks(): List<TrackInfo> {
     return tracks
 }
 
-fun MappingTrackSelector.audioTracks() = tracks().filter { it.rendererType == TRACK_TYPE_AUDIO }
-
-fun MappingTrackSelector.subtitleTracks() = tracks().filter { it.rendererType == TRACK_TYPE_TEXT }
-
 private fun String?.toStandardAudioLanguage() = audioStandardMap.entries
     .firstOrNull { this?.toLowerCase(Locale.getDefault()) in it.value }?.key
     ?: this?.toLowerCase(Locale.getDefault())
@@ -82,6 +78,17 @@ private fun String?.toStandardSubtitleLanguage() = subtitleStandardMap.entries
     .firstOrNull { this?.toLowerCase(Locale.getDefault()) in it.value }?.key
     ?: this?.toLowerCase(Locale.getDefault())
     ?: SubtitleLanguage.OFF.value
+
+private val audioStandardMap = mapOf(
+    AudioLanguage.ORIGINAL.value to listOf("original", "und"),
+    AudioLanguage.PORTUGUESE.value to listOf("pt", "por"),
+    AudioLanguage.ENGLISH.value to listOf("en", "eng")
+)
+
+private val subtitleStandardMap = mapOf(
+    SubtitleLanguage.OFF.value to listOf("", "off"),
+    SubtitleLanguage.PORTUGUESE.value to listOf("pt", "por")
+)
 
 data class TrackInfo(
     val rendererType: Int,

--- a/clappr/src/main/kotlin/io/clappr/player/playback/ExoPlayerExtensions.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/playback/ExoPlayerExtensions.kt
@@ -3,6 +3,7 @@ package io.clappr.player.playback
 import com.google.android.exoplayer2.C.TRACK_TYPE_AUDIO
 import com.google.android.exoplayer2.C.TRACK_TYPE_TEXT
 import com.google.android.exoplayer2.Player
+import com.google.android.exoplayer2.trackselection.DefaultTrackSelector
 import com.google.android.exoplayer2.trackselection.MappingTrackSelector
 import io.clappr.player.components.AudioLanguage
 import io.clappr.player.components.SubtitleLanguage
@@ -67,6 +68,50 @@ private fun MappingTrackSelector.tracks(): List<TrackInfo> {
     }
 
     return tracks
+}
+
+fun DefaultTrackSelector.setAudioFromTracks(language: String) {
+    val currentMappedTrackInfo = currentMappedTrackInfo ?: return
+
+    val targetTrack = audioTracks().first { it.language == language }
+
+    parameters = DefaultTrackSelector.ParametersBuilder()
+        .setRendererDisabled(targetTrack.rendererIndex, false)
+        .build()
+
+    val selectionOverride = DefaultTrackSelector.SelectionOverride(
+        targetTrack.trackGroupIndex,
+        targetTrack.formatIndex
+    )
+
+    parameters = DefaultTrackSelector.ParametersBuilder()
+        .setSelectionOverride(
+            targetTrack.rendererIndex,
+            currentMappedTrackInfo.getTrackGroups(targetTrack.rendererIndex),
+            selectionOverride
+        ).build()
+}
+
+fun DefaultTrackSelector.selectSubtitleFromTracks(language: String) {
+    val currentMappedTrackInfo = currentMappedTrackInfo ?: return
+
+    val track = subtitleTracks().first { it.language == language }
+
+    parameters = DefaultTrackSelector.ParametersBuilder()
+        .setRendererDisabled(track.rendererIndex, false)
+        .build()
+
+    val selectionOverride = DefaultTrackSelector.SelectionOverride(
+        track.trackGroupIndex,
+        track.formatIndex
+    )
+
+    parameters = DefaultTrackSelector.ParametersBuilder()
+        .setSelectionOverride(
+            track.rendererIndex,
+            currentMappedTrackInfo.getTrackGroups(track.rendererIndex),
+            selectionOverride
+        ).build()
 }
 
 private fun String?.toStandardAudioLanguage() = audioStandardMap.entries

--- a/clappr/src/main/kotlin/io/clappr/player/playback/ExoPlayerExtensions.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/playback/ExoPlayerExtensions.kt
@@ -70,32 +70,23 @@ private fun MappingTrackSelector.tracks(): List<TrackInfo> {
     return tracks
 }
 
-fun DefaultTrackSelector.setAudioFromTracks(language: String) {
+fun DefaultTrackSelector.setAudioFromTracks(language: String) = selectAudio(language)
+
+fun DefaultTrackSelector.selectSubtitleFromTracks(language: String) = selectSubtitle(language)
+
+private fun DefaultTrackSelector.selectAudio(language: String) =
+    selectTrack(audioTracks(), language)
+
+private fun DefaultTrackSelector.selectSubtitle(language: String) =
+    selectTrack(subtitleTracks(), language)
+
+private fun DefaultTrackSelector.selectTrack(
+    tracks: List<TrackInfo>,
+    language: String
+) {
     val currentMappedTrackInfo = currentMappedTrackInfo ?: return
 
-    val targetTrack = audioTracks().first { it.language == language }
-
-    parameters = DefaultTrackSelector.ParametersBuilder()
-        .setRendererDisabled(targetTrack.rendererIndex, false)
-        .build()
-
-    val selectionOverride = DefaultTrackSelector.SelectionOverride(
-        targetTrack.trackGroupIndex,
-        targetTrack.formatIndex
-    )
-
-    parameters = DefaultTrackSelector.ParametersBuilder()
-        .setSelectionOverride(
-            targetTrack.rendererIndex,
-            currentMappedTrackInfo.getTrackGroups(targetTrack.rendererIndex),
-            selectionOverride
-        ).build()
-}
-
-fun DefaultTrackSelector.selectSubtitleFromTracks(language: String) {
-    val currentMappedTrackInfo = currentMappedTrackInfo ?: return
-
-    val track = subtitleTracks().first { it.language == language }
+    val track = tracks.first { it.language == language }
 
     parameters = DefaultTrackSelector.ParametersBuilder()
         .setRendererDisabled(track.rendererIndex, false)

--- a/clappr/src/main/kotlin/io/clappr/player/playback/ExoPlayerExtensions.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/playback/ExoPlayerExtensions.kt
@@ -9,8 +9,8 @@ import io.clappr.player.components.SubtitleLanguage
 import java.util.*
 
 fun Player.getSelectedAudio(trackSelector: MappingTrackSelector): String {
-    val rendererIndex = trackSelector.audioTracks()
-        .firstOrNull()?.rendererIndex ?: return AudioLanguage.UNSET.value
+    val rendererIndex = trackSelector.audioTracks().firstOrNull()?.rendererIndex
+        ?: return AudioLanguage.UNSET.value
 
     val selectedFormat = currentTrackSelections.get(rendererIndex)?.selectedFormat
         ?: return AudioLanguage.UNSET.value

--- a/clappr/src/main/kotlin/io/clappr/player/playback/ExoPlayerExtensions.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/playback/ExoPlayerExtensions.kt
@@ -1,0 +1,67 @@
+package io.clappr.player.playback
+
+import com.google.android.exoplayer2.C.TRACK_TYPE_AUDIO
+import com.google.android.exoplayer2.C.TRACK_TYPE_TEXT
+import com.google.android.exoplayer2.Player
+import com.google.android.exoplayer2.trackselection.MappingTrackSelector
+import io.clappr.player.components.AudioLanguage.ORIGINAL
+import io.clappr.player.components.SubtitleLanguage.OFF
+
+val Player.selectedSubtitle
+    get() = currentTrackSelections.get(TRACK_TYPE_TEXT)?.selectedFormat?.language ?: OFF.value
+
+val Player.selectedAudio
+    get() = currentTrackSelections.get(TRACK_TYPE_AUDIO)?.selectedFormat?.language ?: ORIGINAL.value
+
+fun MappingTrackSelector.tracks(): List<TrackInfo> {
+
+    val tracks = mutableListOf<TrackInfo>()
+
+    val mappedTrackInfo = currentMappedTrackInfo ?: return tracks
+
+    for (rendererIndex in 0 until mappedTrackInfo.rendererCount) {
+
+        val rendererType = mappedTrackInfo.getRendererType(rendererIndex)
+        val trackGroupArray = mappedTrackInfo.getTrackGroups(rendererIndex)
+
+        for (trackGroupIndex in 0 until trackGroupArray.length) {
+
+            val trackGroup = trackGroupArray.get(trackGroupIndex)
+
+            for (formatIndex in 0 until trackGroup.length) {
+
+                val format = trackGroup.getFormat(formatIndex)
+                val language = format.language ?: when (rendererType) {
+                    TRACK_TYPE_AUDIO -> ORIGINAL.value
+                    else -> OFF.value
+                }
+
+                tracks += TrackInfo(
+                    rendererType,
+                    rendererIndex,
+                    trackGroupIndex,
+                    formatIndex,
+                    language
+                )
+            }
+        }
+    }
+
+    return tracks
+}
+
+fun MappingTrackSelector.audioTracks() = tracks().filter {
+    currentMappedTrackInfo?.getRendererType(it.rendererIndex) == TRACK_TYPE_AUDIO
+}
+
+fun MappingTrackSelector.subtitleTracks() = tracks().filter {
+    currentMappedTrackInfo?.getRendererType(it.rendererIndex) == TRACK_TYPE_TEXT
+}
+
+data class TrackInfo(
+    val rendererType: Int,
+    val rendererIndex: Int,
+    val trackGroupIndex: Int,
+    val formatIndex: Int,
+    val language: String
+)

--- a/clappr/src/main/kotlin/io/clappr/player/playback/ExoPlayerPlayback.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/playback/ExoPlayerPlayback.kt
@@ -114,15 +114,16 @@ open class ExoPlayerPlayback(
         }
 
     private val syncBufferInSeconds =
-        if (mediaType == LIVE) Companion.DEFAULT_SYNC_BUFFER_IN_SECONDS + Companion.MIN_DVR_LIVE_DRIFT else 0
+        if (mediaType == LIVE) DEFAULT_SYNC_BUFFER_IN_SECONDS + MIN_DVR_LIVE_DRIFT else 0
 
     override val duration: Double
-        get() = player?.duration?.let { (it.toDouble() / Companion.ONE_SECOND_IN_MILLIS) - syncBufferInSeconds }
+        get() = player?.duration?.let { (it.toDouble() / ONE_SECOND_IN_MILLIS) - syncBufferInSeconds }
             ?: Double.NaN
 
     override val position: Double
-        get() = player?.currentPosition?.let { min(it.toDouble() / Companion.ONE_SECOND_IN_MILLIS, duration) }
-            ?: Double.NaN
+        get() = player?.currentPosition?.let {
+            min(it.toDouble() / ONE_SECOND_IN_MILLIS, duration)
+        } ?: Double.NaN
 
     override val state: State
         get() = currentState
@@ -297,7 +298,7 @@ open class ExoPlayerPlayback(
         if (!canSeek) return false
 
         trigger(WILL_SEEK)
-        player?.seekTo((seconds * Companion.ONE_SECOND_IN_MILLIS).toLong())
+        player?.seekTo((seconds * ONE_SECOND_IN_MILLIS).toLong())
         trigger(DID_SEEK)
         triggerPositionUpdateEvent()
 
@@ -306,7 +307,7 @@ open class ExoPlayerPlayback(
 
     override fun startAt(seconds: Int): Boolean {
         if (!canSeek) return false
-        player?.seekTo((seconds * Companion.ONE_SECOND_IN_MILLIS).toLong())
+        player?.seekTo((seconds * ONE_SECOND_IN_MILLIS).toLong())
         triggerPositionUpdateEvent()
 
         return true
@@ -583,22 +584,24 @@ open class ExoPlayerPlayback(
 
     private fun setupBuiltInAudios() {
         val player = player ?: return
-        val audioTracks = trackSelector?.audioTracks() ?: return
+        val trackSelector = trackSelector ?: return
+        val audioTracks = trackSelector.audioTracks()
 
         availableAudios += audioTracks.map { it.language }
 
-        internalSelectedAudio = player.selectedAudio
+        internalSelectedAudio = player.getSelectedAudio(trackSelector)
 
         if (audioTracks.any()) trigger(DID_FIND_AUDIO.value)
     }
 
     private fun setupBuiltInSubtitles() {
         val player = player ?: return
-        val subtitleTracks = trackSelector?.subtitleTracks() ?: return
+        val trackSelector = trackSelector ?: return
+        val subtitleTracks = trackSelector.subtitleTracks()
 
         availableSubtitles += listOf(SubtitleLanguage.OFF.value) + subtitleTracks.map { it.language }
 
-        internalSelectedSubtitle = player.selectedSubtitle
+        internalSelectedSubtitle = player.getSelectedSubtitle(trackSelector)
 
         if (subtitleTracks.any()) trigger(DID_FIND_SUBTITLE.value)
     }
@@ -740,7 +743,8 @@ open class ExoPlayerPlayback(
             timeline?.takeIf { isDvrAvailable && it.windowCount > 0 }?.let {
                 var currentWindow = Timeline.Window()
                 currentWindow = it.getWindow(0, currentWindow)
-                dvrStartTimeInSeconds = currentWindow.windowStartTimeMs / Companion.ONE_SECOND_IN_MILLIS
+                dvrStartTimeInSeconds =
+                    currentWindow.windowStartTimeMs / Companion.ONE_SECOND_IN_MILLIS
             }
         }
 
@@ -797,7 +801,8 @@ open class ExoPlayerPlayback(
         private const val ONE_SECOND_IN_MILLIS: Int = 1000
         private const val DEFAULT_MIN_DVR_SIZE = 60
         private const val MIN_DVR_LIVE_DRIFT = 5
-        private const val DEFAULT_SYNC_BUFFER_IN_SECONDS = DEFAULT_MIN_BUFFER_MS / ONE_SECOND_IN_MILLIS
+        private const val DEFAULT_SYNC_BUFFER_IN_SECONDS =
+            DEFAULT_MIN_BUFFER_MS / ONE_SECOND_IN_MILLIS
 
         val supportsSource: PlaybackSupportCheck = { source, _ ->
             val uri = Uri.parse(source)

--- a/clappr/src/main/kotlin/io/clappr/player/playback/ExoPlayerPlayback.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/playback/ExoPlayerPlayback.kt
@@ -572,9 +572,9 @@ open class ExoPlayerPlayback(
             setupBuiltInSubtitles()
         }
 
-        selectFirstAudioIfAvailableAndUnset()
-
         setupInitialMediasFromClapprOptions()
+
+        selectFirstAudioIfAvailableAndUnset()
     }
 
     private fun selectFirstAudioIfAvailableAndUnset() {

--- a/clappr/src/main/kotlin/io/clappr/player/playback/ExoPlayerPlayback.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/playback/ExoPlayerPlayback.kt
@@ -279,7 +279,7 @@ open class ExoPlayerPlayback(
         shouldInitializeAudioAndSubtitles = true
         availableAudios.clear()
         availableSubtitles.clear()
-        internalSelectedAudio = AudioLanguage.UNSET.value
+        internalSelectedAudio = null
         internalSelectedSubtitle = SubtitleLanguage.OFF.value
         bitrateHistory.clear()
 
@@ -578,7 +578,7 @@ open class ExoPlayerPlayback(
     }
 
     private fun selectFirstAudioIfAvailableAndUnset() {
-        if (availableAudios.isNotEmpty() && selectedAudio == AudioLanguage.UNSET.value)
+        if (availableAudios.isNotEmpty() && selectedAudio == null)
             selectedAudio = availableAudios.first()
     }
 
@@ -615,10 +615,11 @@ open class ExoPlayerPlayback(
         if (subtitlesFromOptions.any()) trigger(DID_FIND_SUBTITLE.value)
     }
 
-    override var selectedAudio: String
+    override var selectedAudio: String?
         get() = super.selectedAudio
         set(value) {
-            setAudioOnPlayback(value)
+            if (value != null)
+                setAudioOnPlayback(value)
             super.selectedAudio = value
             Logger.info(tag, "selectedAudio")
         }

--- a/clappr/src/test/kotlin/io/clappr/player/PlayerTest.kt
+++ b/clappr/src/test/kotlin/io/clappr/player/PlayerTest.kt
@@ -409,6 +409,16 @@ open class PlayerTest {
     }
 
     @Test
+    fun `should listen media option update event out of player`() {
+        assertPlaybackEventWasTriggered(Event.MEDIA_OPTIONS_UPDATE.value)
+    }
+
+    @Test
+    fun `should listen media option selected event out of player triggered by core`() {
+        assertCoreEventWasTriggered(Event.MEDIA_OPTIONS_SELECTED.value)
+    }
+
+    @Test
     fun `should listen did select audio event out of player triggered by core`() {
         assertCoreEventWasTriggered(Event.DID_SELECT_AUDIO.value)
     }

--- a/clappr/src/test/kotlin/io/clappr/player/PlayerTest.kt
+++ b/clappr/src/test/kotlin/io/clappr/player/PlayerTest.kt
@@ -409,13 +409,13 @@ open class PlayerTest {
     }
 
     @Test
-    fun `should listen media option update event out of player`() {
-        assertPlaybackEventWasTriggered(Event.MEDIA_OPTIONS_UPDATE.value)
+    fun `should listen did select audio event out of player triggered by core`() {
+        assertCoreEventWasTriggered(Event.DID_SELECT_AUDIO.value)
     }
 
     @Test
-    fun `should listen media option selected event out of player triggered by core`() {
-        assertCoreEventWasTriggered(Event.MEDIA_OPTIONS_SELECTED.value)
+    fun `should listen did select subtitle event out of player triggered by core`() {
+        assertCoreEventWasTriggered(Event.DID_SELECT_SUBTITLE.value)
     }
 
     @Test

--- a/clappr/src/test/kotlin/io/clappr/player/components/MediaOptionTest.kt
+++ b/clappr/src/test/kotlin/io/clappr/player/components/MediaOptionTest.kt
@@ -1,13 +1,28 @@
 package io.clappr.player.components
 
+import com.nhaarman.mockito_kotlin.doReturn
+import com.nhaarman.mockito_kotlin.mock
+import com.nhaarman.mockito_kotlin.whenever
 import org.junit.Assert.assertEquals
+import org.junit.Before
 import org.junit.Test
 
 class MediaOptionTest {
 
+    private lateinit var playback: Playback
+
+    @Before
+    fun setUp() {
+        playback = mock()
+    }
+
     @Test
     fun `should create media options json with audio and subtitle`() {
-        val mediaOptionsJson = buildMediaOptionsJson("por", "eng")
+
+        whenever(playback.selectedAudio) doReturn "eng"
+        whenever(playback.selectedSubtitle) doReturn "por"
+
+        val mediaOptionsJson = playback.buildMediaOptionsJson()
         val expectedJson = """{"media_option":[{"name":"por","type":"SUBTITLE"},{"name":"eng","type":"AUDIO"}]}}"""
 
         assertEquals(expectedJson, mediaOptionsJson)
@@ -15,7 +30,9 @@ class MediaOptionTest {
 
     @Test
     fun `should create media options json only with subtitle`() {
-        val mediaOptionsJson = buildMediaOptionsJson("por", null)
+        whenever(playback.selectedSubtitle) doReturn "por"
+
+        val mediaOptionsJson = playback.buildMediaOptionsJson()
         val expectedJson = """{"media_option":[{"name":"por","type":"SUBTITLE"}]}}"""
 
         assertEquals(expectedJson, mediaOptionsJson)

--- a/clappr/src/test/kotlin/io/clappr/player/components/MediaOptionTest.kt
+++ b/clappr/src/test/kotlin/io/clappr/player/components/MediaOptionTest.kt
@@ -1,0 +1,23 @@
+package io.clappr.player.components
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class MediaOptionTest {
+
+    @Test
+    fun `should create media options json with audio and subtitle`() {
+        val mediaOptionsJson = buildMediaOptionsJson("por", "eng")
+        val expectedJson = """{"media_option":[{"name":"por","type":"SUBTITLE"},{"name":"eng","type":"AUDIO"}]}}"""
+
+        assertEquals(expectedJson, mediaOptionsJson)
+    }
+
+    @Test
+    fun `should create media options json only with subtitle`() {
+        val mediaOptionsJson = buildMediaOptionsJson("por", null)
+        val expectedJson = """{"media_option":[{"name":"por","type":"SUBTITLE"}]}}"""
+
+        assertEquals(expectedJson, mediaOptionsJson)
+    }
+}

--- a/clappr/src/test/kotlin/io/clappr/player/components/PlaybackTest.kt
+++ b/clappr/src/test/kotlin/io/clappr/player/components/PlaybackTest.kt
@@ -27,9 +27,9 @@ import java.util.*
 open class PlaybackTest {
 
     class SomePlayback(
-            source: String, options: Options = Options(),
-            private val aMediaType: MediaType = MediaType.UNKNOWN) :
-            Playback(source, null, options, name = name, supportsSource = supportsSource) {
+        source: String, options: Options = Options(),
+        private val aMediaType: MediaType = MediaType.UNKNOWN
+    ) : Playback(source, null, options, name = name, supportsSource = supportsSource) {
         companion object {
             const val name = ""
 
@@ -40,6 +40,8 @@ open class PlaybackTest {
 
         var playWasCalled = false
         var startAtWasCalled = false
+        var changeAudioTrackCalled = false
+        var changeSubtitleTrackCalled = false
         var startAtValueInSeconds: Int = 0
 
         override val mediaType: MediaType
@@ -57,6 +59,14 @@ open class PlaybackTest {
         }
 
         val hasSelectedMediaOption = selectedMediaOptionList.isNotEmpty()
+
+        override fun changeAudioTrack(name: String) {
+            changeAudioTrackCalled = true
+        }
+
+        override fun changeSubtitleTrack(name: String) {
+            changeSubtitleTrackCalled = true
+        }
     }
 
     @Before
@@ -132,16 +142,28 @@ open class PlaybackTest {
         assertFalse("Should not call start at for live videos", playback.startAtWasCalled)
     }
 
-    private fun testPlaybackStartAt(startAtValue: Any, shouldAssertStartAtValue: Boolean, mediaType: Playback.MediaType = Playback.MediaType.UNKNOWN) {
+    private fun testPlaybackStartAt(
+        startAtValue: Any,
+        shouldAssertStartAtValue: Boolean,
+        mediaType: Playback.MediaType = Playback.MediaType.UNKNOWN
+    ) {
         val option = Options().also { it[START_AT.value] = startAtValue }
         val playback = SomePlayback("valid-source.mp4", option, mediaType)
 
         playback.render()
         playback.trigger(READY.value)
 
-        assertEquals("startAt should be called when start at is set", shouldAssertStartAtValue, playback.startAtWasCalled)
+        assertEquals(
+            "startAt should be called when start at is set",
+            shouldAssertStartAtValue,
+            playback.startAtWasCalled
+        )
         if (shouldAssertStartAtValue) {
-            assertEquals("startAt value in seconds ", (startAtValue as Number).toInt() , playback.startAtValueInSeconds)
+            assertEquals(
+                "startAt value in seconds ",
+                (startAtValue as Number).toInt(),
+                playback.startAtValueInSeconds
+            )
         }
     }
 
@@ -162,7 +184,8 @@ open class PlaybackTest {
     }
 
     @Test
-    @Ignore @SuppressLint("IgnoreWithoutReason")
+    @Ignore
+    @SuppressLint("IgnoreWithoutReason")
     fun shouldTriggerEventsOnDestroy() {
         val listenObject = BaseObject()
         val playback = SomePlayback("valid-source.mp4", Options())
@@ -203,7 +226,8 @@ open class PlaybackTest {
     }
 
     private fun insertMedia(
-            playback: Playback, mediaOptionType: MediaOptionType, quantity: Int): MutableList<MediaOption> {
+        playback: Playback, mediaOptionType: MediaOptionType, quantity: Int
+    ): MutableList<MediaOption> {
         val mediaOptionList: MutableList<MediaOption> = ArrayList()
         for (i in 1..quantity) {
             val mediaOption = MediaOption("Name $i", mediaOptionType, i, null)
@@ -278,7 +302,9 @@ open class PlaybackTest {
 
         var mediaOptionsUpdateCalled = false
 
-        listenObject.listenTo(playback, MEDIA_OPTIONS_UPDATE.value) { mediaOptionsUpdateCalled = true }
+        listenObject.listenTo(playback, MEDIA_OPTIONS_UPDATE.value) {
+            mediaOptionsUpdateCalled = true
+        }
 
         playback.setSelectedMediaOption(MediaOption("Name", SUBTITLE, "name", null))
 
@@ -351,9 +377,10 @@ open class PlaybackTest {
         val jsonMediaOptionName = PORTUGUESE.value
         val jsonMediaOptionType = AUDIO
         val validJsonWithUpperCase =
-                convertMediaOptionsToJson(jsonMediaOptionType.name, jsonMediaOptionName.toUpperCase())
+            convertMediaOptionsToJson(jsonMediaOptionType.name, jsonMediaOptionName.toUpperCase())
 
-        val options = Options(options = hashMapOf(SELECTED_MEDIA_OPTIONS.value to validJsonWithUpperCase))
+        val options =
+            Options(options = hashMapOf(SELECTED_MEDIA_OPTIONS.value to validJsonWithUpperCase))
 
         setupPlaybackWithMediaOptions(options).run {
             assertSelectedMediaOption(this, jsonMediaOptionType, jsonMediaOptionName)
@@ -365,8 +392,9 @@ open class PlaybackTest {
         val jsonMediaOptionName = SubtitleLanguage.PORTUGUESE.value
         val jsonMediaOptionType = SUBTITLE
         val validJsonWithUpperCase =
-                convertMediaOptionsToJson(jsonMediaOptionType.name, jsonMediaOptionName.toUpperCase())
-        val options = Options(options = hashMapOf(SELECTED_MEDIA_OPTIONS.value to validJsonWithUpperCase))
+            convertMediaOptionsToJson(jsonMediaOptionType.name, jsonMediaOptionName.toUpperCase())
+        val options =
+            Options(options = hashMapOf(SELECTED_MEDIA_OPTIONS.value to validJsonWithUpperCase))
 
         setupPlaybackWithMediaOptions(options).run {
             assertSelectedMediaOption(this, jsonMediaOptionType, jsonMediaOptionName)
@@ -379,10 +407,12 @@ open class PlaybackTest {
         val jsonMediaOptionType = AUDIO
         val validJson = convertMediaOptionsToJson(jsonMediaOptionType.name, jsonMediaOptionName)
 
-        val options = Options(options = hashMapOf(
-            SELECTED_MEDIA_OPTIONS.value to validJson,
-            DEFAULT_AUDIO.value to "por"
-        ))
+        val options = Options(
+            options = hashMapOf(
+                SELECTED_MEDIA_OPTIONS.value to validJson,
+                DEFAULT_AUDIO.value to "por"
+            )
+        )
 
         setupPlaybackWithMediaOptions(options).run {
             assertSelectedMediaOption(this, jsonMediaOptionType, "por")
@@ -395,10 +425,12 @@ open class PlaybackTest {
         val jsonMediaOptionType = SUBTITLE
         val validJson = convertMediaOptionsToJson(jsonMediaOptionType.name, jsonMediaOptionName)
 
-        val options = Options(options = hashMapOf(
-            SELECTED_MEDIA_OPTIONS.value to validJson,
-            DEFAULT_SUBTITLE.value to "off"
-        ))
+        val options = Options(
+            options = hashMapOf(
+                SELECTED_MEDIA_OPTIONS.value to validJson,
+                DEFAULT_SUBTITLE.value to "off"
+            )
+        )
 
         setupPlaybackWithMediaOptions(options).run {
             assertSelectedMediaOption(this, jsonMediaOptionType, "off")
@@ -412,19 +444,25 @@ open class PlaybackTest {
         val jsonMediaOptionNameSubtitle = SubtitleLanguage.PORTUGUESE.value
         val jsonMediaOptionTypeSubtitle = SUBTITLE
         val validJson = convertMediaOptionsToJson(
-                jsonMediaOptionTypeAudio.name, jsonMediaOptionNameAudio,
-                jsonMediaOptionTypeSubtitle.name, jsonMediaOptionNameSubtitle)
+            jsonMediaOptionTypeAudio.name, jsonMediaOptionNameAudio,
+            jsonMediaOptionTypeSubtitle.name, jsonMediaOptionNameSubtitle
+        )
 
         val options = Options(options = hashMapOf(SELECTED_MEDIA_OPTIONS.value to validJson))
 
         setupPlaybackWithMediaOptions(options).run {
             assertSelectedMediaOption(this, jsonMediaOptionTypeAudio, jsonMediaOptionNameAudio)
-            assertSelectedMediaOption(this, jsonMediaOptionTypeSubtitle, jsonMediaOptionNameSubtitle)
+            assertSelectedMediaOption(
+                this,
+                jsonMediaOptionTypeSubtitle,
+                jsonMediaOptionNameSubtitle
+            )
         }
     }
 
     private fun assertSelectedMediaOption(
-            playback: SomePlayback, expectedType: MediaOptionType, expectedValue: String) {
+        playback: SomePlayback, expectedType: MediaOptionType, expectedValue: String
+    ) {
         val optionSelected = playback.selectedMediaOption(expectedType)
         assertEquals(expectedValue, optionSelected?.name)
         assertEquals(expectedType.name, optionSelected?.type?.name)
@@ -437,8 +475,9 @@ open class PlaybackTest {
     }
 
     private fun convertMediaOptionsToJson(
-            jsonMediaOptionTypeAudio: String? = null, jsonMediaOptionNameAudio: String? = null,
-            jsonMediaOptionTypeSubtitle: String? = null, jsonMediaOptionNameSubtitle: String? = null): String {
+        jsonMediaOptionTypeAudio: String? = null, jsonMediaOptionNameAudio: String? = null,
+        jsonMediaOptionTypeSubtitle: String? = null, jsonMediaOptionNameSubtitle: String? = null
+    ): String {
         val mediaOptionsArrayJson = "media_option"
         val mediaOptionsNameJson = "name"
         val mediaOptionsTypeJson = "type"
@@ -513,10 +552,11 @@ open class PlaybackTest {
         return playback
     }
 
-    private fun mediaOption(name: String, type: MediaOptionType) = MediaOption(name, type, null, null)
+    private fun mediaOption(name: String, type: MediaOptionType) =
+        MediaOption(name, type, null, null)
 
     @Test
-    fun shouldTriggerDidSelectAudioWhenAudioIsSet() {
+    fun shouldTriggerEventAndChangeTrackWhenAudioIsSet() {
         val playback = SomePlayback("valid-source.mp4", Options())
 
         playback.availableAudios += listOf("eng", "por")
@@ -527,10 +567,11 @@ open class PlaybackTest {
         playback.selectedAudio = "eng"
 
         assertTrue(didSelectAudioWasTriggered)
+        assertTrue(playback.changeAudioTrackCalled)
     }
 
     @Test
-    fun shouldNotTriggerDidSelectAudioWhenUnavailableAudioIsSet() {
+    fun shouldNotTriggerEventAndChangeTrackWhenUnavailableAudioIsSet() {
         val playback = SomePlayback("valid-source.mp4", Options())
 
         playback.availableAudios += listOf("eng", "por")
@@ -541,5 +582,36 @@ open class PlaybackTest {
         playback.selectedAudio = "fr"
 
         assertFalse(didSelectAudioWasTriggered)
+        assertFalse(playback.changeAudioTrackCalled)
+    }
+
+    @Test
+    fun shouldTriggerEventAndChangeTrackWhenSubtitleIsSet() {
+        val playback = SomePlayback("valid-source.mp4", Options())
+
+        playback.availableSubtitles += listOf("eng", "por")
+
+        var didSelectSubtitleWasTriggered = false
+        playback.on(DID_SELECT_SUBTITLE.value) { didSelectSubtitleWasTriggered = true }
+
+        playback.selectedSubtitle = "eng"
+
+        assertTrue(didSelectSubtitleWasTriggered)
+        assertTrue(playback.changeSubtitleTrackCalled)
+    }
+
+    @Test
+    fun shouldNotTriggerEventAndChangeTrackWhenUnavailableSubtitleIsSet() {
+        val playback = SomePlayback("valid-source.mp4", Options())
+
+        playback.availableSubtitles += listOf("eng", "por")
+
+        var didSelectSubtitleWasTriggered = false
+        playback.on(DID_SELECT_SUBTITLE.value) { didSelectSubtitleWasTriggered = true }
+
+        playback.selectedSubtitle = "fr"
+
+        assertFalse(didSelectSubtitleWasTriggered)
+        assertFalse(playback.changeSubtitleTrackCalled)
     }
 }

--- a/clappr/src/test/kotlin/io/clappr/player/components/PlaybackTest.kt
+++ b/clappr/src/test/kotlin/io/clappr/player/components/PlaybackTest.kt
@@ -235,7 +235,7 @@ class PlaybackTest {
 
         val selectedAudio = playback.selectedAudio
 
-        assertEquals(AudioLanguage.UNSET.value, selectedAudio)
+        assertEquals(null, selectedAudio)
     }
 
     @Test

--- a/clappr/src/test/kotlin/io/clappr/player/components/PlaybackTest.kt
+++ b/clappr/src/test/kotlin/io/clappr/player/components/PlaybackTest.kt
@@ -5,7 +5,7 @@ import androidx.test.core.app.ApplicationProvider
 import io.clappr.player.base.BaseObject
 import io.clappr.player.base.ClapprOption.*
 import io.clappr.player.base.Event.*
-import io.clappr.player.base.InternalEvent
+import io.clappr.player.base.InternalEvent.*
 import io.clappr.player.base.Options
 import io.clappr.player.components.AudioLanguage.*
 import io.clappr.player.components.MediaOptionType.AUDIO
@@ -169,8 +169,8 @@ open class PlaybackTest {
 
         var willDestroyCalled = false
         var didDestroyCalled = false
-        listenObject.listenTo(playback, InternalEvent.WILL_DESTROY.value) { willDestroyCalled = true }
-        listenObject.listenTo(playback, InternalEvent.DID_DESTROY.value) { didDestroyCalled = true }
+        listenObject.listenTo(playback, WILL_DESTROY.value) { willDestroyCalled = true }
+        listenObject.listenTo(playback, DID_DESTROY.value) { didDestroyCalled = true }
 
         playback.destroy()
 
@@ -469,7 +469,7 @@ open class PlaybackTest {
         val playback = SomePlayback("valid-source.mp4", Options())
 
         var callbackWasCalled = false
-        playback.on(InternalEvent.DID_UPDATE_OPTIONS.value) { callbackWasCalled = true }
+        playback.on(DID_UPDATE_OPTIONS.value) { callbackWasCalled = true }
 
         playback.options = Options(source = "new_source")
 
@@ -514,4 +514,32 @@ open class PlaybackTest {
     }
 
     private fun mediaOption(name: String, type: MediaOptionType) = MediaOption(name, type, null, null)
+
+    @Test
+    fun shouldTriggerDidSelectAudioWhenAudioIsSet() {
+        val playback = SomePlayback("valid-source.mp4", Options())
+
+        playback.availableAudios += listOf("eng", "por")
+
+        var didSelectAudioWasTriggered = false
+        playback.on(DID_SELECT_AUDIO.value) { didSelectAudioWasTriggered = true }
+
+        playback.selectedAudio = "eng"
+
+        assertTrue(didSelectAudioWasTriggered)
+    }
+
+    @Test
+    fun shouldNotTriggerDidSelectAudioWhenUnavailableAudioIsSet() {
+        val playback = SomePlayback("valid-source.mp4", Options())
+
+        playback.availableAudios += listOf("eng", "por")
+
+        var didSelectAudioWasTriggered = false
+        playback.on(DID_SELECT_AUDIO.value) { didSelectAudioWasTriggered = true }
+
+        playback.selectedAudio = "fr"
+
+        assertFalse(didSelectAudioWasTriggered)
+    }
 }

--- a/clappr/src/test/kotlin/io/clappr/player/components/PlaybackTest.kt
+++ b/clappr/src/test/kotlin/io/clappr/player/components/PlaybackTest.kt
@@ -306,7 +306,7 @@ class PlaybackTest {
     fun shouldTriggerEventAndChangeTrackWhenSubtitleIsSet() {
         val playback = SomePlayback("valid-source.mp4")
 
-        playback.availableAudios += setOf(
+        playback.availableSubtitles += setOf(
             AudioLanguage.ENGLISH.value,
             AudioLanguage.PORTUGUESE.value
         )
@@ -322,12 +322,6 @@ class PlaybackTest {
     @Test(expected = IllegalArgumentException::class)
     fun shouldNotTriggerEventAndChangeTrackWhenUnavailableSubtitleIsSet() {
         val playback = SomePlayback("valid-source.mp4")
-
-        playback.availableAudios += setOf(
-            AudioLanguage.ENGLISH.value,
-            AudioLanguage.PORTUGUESE.value
-        )
-
         playback.selectedSubtitle = "fr"
     }
 

--- a/clappr/src/test/kotlin/io/clappr/player/components/PlaybackTest.kt
+++ b/clappr/src/test/kotlin/io/clappr/player/components/PlaybackTest.kt
@@ -6,6 +6,7 @@ import io.clappr.player.base.BaseObject
 import io.clappr.player.base.ClapprOption
 import io.clappr.player.base.ClapprOption.START_AT
 import io.clappr.player.base.Event.*
+import io.clappr.player.base.EventData
 import io.clappr.player.base.InternalEvent.*
 import io.clappr.player.base.Options
 import io.clappr.player.playback.NoOpPlayback
@@ -185,51 +186,53 @@ class PlaybackTest {
     }
 
     @Test
-    fun shouldSetSelectedMediaOptionAudio() {
+    fun shouldTriggerDidUpdateAudioAndMediaOptionsUpdateWhenAudioIsChanged() {
         val playback = SomePlayback("valid-source.mp4")
 
         val languages = (1..3).map { "Name $it" }
         playback.availableAudios += languages
 
-        var didUpdateAudioTriggered = false
+        var updatedAudio: String? = null
         var mediaOptionsUpdateTriggered = false
 
-        playback.on(DID_UPDATE_AUDIO.value) { didUpdateAudioTriggered = true }
+        playback.on(DID_UPDATE_AUDIO.value) {
+            updatedAudio = it?.getString(EventData.UPDATED_AUDIO.value)
+        }
         playback.on(MEDIA_OPTIONS_UPDATE.value) { mediaOptionsUpdateTriggered = true }
 
         languages.forEach {
             playback.selectedAudio = it
 
-            assertEquals(it, playback.selectedAudio)
-            assertTrue(didUpdateAudioTriggered)
+            assertEquals(it, updatedAudio)
             assertTrue(mediaOptionsUpdateTriggered)
 
-            didUpdateAudioTriggered = false
+            updatedAudio = null
             mediaOptionsUpdateTriggered = false
         }
     }
 
     @Test
-    fun shouldSetSelectedMediaOptionSubtitle() {
+    fun shouldTriggerDidUpdateSubtitleAndMediaOptionsUpdateWhenSubtitleIsChanged() {
         val playback = SomePlayback("valid-source.mp4")
 
         val languages = (1..3).map { "Name $it" }
         playback.availableSubtitles += languages
 
-        var didUpdateSubtitleTriggered = false
+        var updatedSubtitle: String? = null
         var mediaOptionsUpdateTriggered = false
 
-        playback.on(DID_UPDATE_SUBTITLE.value) { didUpdateSubtitleTriggered = true }
+        playback.on(DID_UPDATE_SUBTITLE.value) {
+            updatedSubtitle = it?.getString(EventData.UPDATED_SUBTITLE.value)
+        }
         playback.on(MEDIA_OPTIONS_UPDATE.value) { mediaOptionsUpdateTriggered = true }
 
         languages.forEach {
             playback.selectedSubtitle = it
 
-            assertEquals(it, playback.selectedSubtitle)
-            assertTrue(didUpdateSubtitleTriggered)
+            assertEquals(it, updatedSubtitle)
             assertTrue(mediaOptionsUpdateTriggered)
 
-            didUpdateSubtitleTriggered = false
+            updatedSubtitle = null
             mediaOptionsUpdateTriggered = false
         }
     }
@@ -282,23 +285,6 @@ class PlaybackTest {
         assertFalse(didSelectAudio)
     }
 
-    @Test
-    fun shouldTriggerEventAndChangeTrackWhenAudioIsSet() {
-        val playback = SomePlayback("valid-source.mp4")
-
-        playback.availableAudios += setOf(
-            AudioLanguage.ENGLISH.value,
-            AudioLanguage.PORTUGUESE.value
-        )
-
-        var didUpdateAudioWasTriggered = false
-        playback.on(DID_UPDATE_AUDIO.value) { didUpdateAudioWasTriggered = true }
-
-        playback.selectedAudio = AudioLanguage.ENGLISH.value
-
-        assertTrue(didUpdateAudioWasTriggered)
-    }
-
     @Test(expected = IllegalArgumentException::class)
     fun shouldNotTriggerEventAndChangeTrackWhenUnavailableAudioIsSet() {
         val playback = SomePlayback("valid-source.mp4")
@@ -309,23 +295,6 @@ class PlaybackTest {
         )
 
         playback.selectedAudio = "fr"
-    }
-
-    @Test
-    fun shouldTriggerEventAndChangeTrackWhenSubtitleIsSet() {
-        val playback = SomePlayback("valid-source.mp4")
-
-        playback.availableSubtitles += setOf(
-            AudioLanguage.ENGLISH.value,
-            AudioLanguage.PORTUGUESE.value
-        )
-
-        var didUpdateSubtitleWasTriggered = false
-        playback.on(DID_UPDATE_SUBTITLE.value) { didUpdateSubtitleWasTriggered = true }
-
-        playback.selectedSubtitle = AudioLanguage.ENGLISH.value
-
-        assertTrue(didUpdateSubtitleWasTriggered)
     }
 
     @Test(expected = IllegalArgumentException::class)

--- a/clappr/src/test/kotlin/io/clappr/player/components/PlaybackTest.kt
+++ b/clappr/src/test/kotlin/io/clappr/player/components/PlaybackTest.kt
@@ -3,7 +3,7 @@ package io.clappr.player.components
 import android.annotation.SuppressLint
 import androidx.test.core.app.ApplicationProvider
 import io.clappr.player.base.BaseObject
-import io.clappr.player.base.ClapprOption.*
+import io.clappr.player.base.ClapprOption.START_AT
 import io.clappr.player.base.Event.*
 import io.clappr.player.base.InternalEvent.*
 import io.clappr.player.base.Options
@@ -277,12 +277,15 @@ class PlaybackTest {
     fun shouldTriggerEventAndChangeTrackWhenAudioIsSet() {
         val playback = SomePlayback("valid-source.mp4")
 
-        playback.availableAudios += setOf("eng", "por")
+        playback.availableAudios += setOf(
+            AudioLanguage.ENGLISH.value,
+            AudioLanguage.PORTUGUESE.value
+        )
 
         var didUpdateAudioWasTriggered = false
         playback.on(DID_UPDATE_AUDIO.value) { didUpdateAudioWasTriggered = true }
 
-        playback.selectedAudio = "eng"
+        playback.selectedAudio = AudioLanguage.ENGLISH.value
 
         assertTrue(didUpdateAudioWasTriggered)
     }
@@ -291,7 +294,10 @@ class PlaybackTest {
     fun shouldNotTriggerEventAndChangeTrackWhenUnavailableAudioIsSet() {
         val playback = SomePlayback("valid-source.mp4")
 
-        playback.availableAudios += setOf("eng", "por")
+        playback.availableAudios += setOf(
+            AudioLanguage.ENGLISH.value,
+            AudioLanguage.PORTUGUESE.value
+        )
 
         playback.selectedAudio = "fr"
     }
@@ -300,12 +306,15 @@ class PlaybackTest {
     fun shouldTriggerEventAndChangeTrackWhenSubtitleIsSet() {
         val playback = SomePlayback("valid-source.mp4")
 
-        playback.availableSubtitles += setOf("eng", "por")
+        playback.availableAudios += setOf(
+            AudioLanguage.ENGLISH.value,
+            AudioLanguage.PORTUGUESE.value
+        )
 
         var didUpdateSubtitleWasTriggered = false
         playback.on(DID_UPDATE_SUBTITLE.value) { didUpdateSubtitleWasTriggered = true }
 
-        playback.selectedSubtitle = "eng"
+        playback.selectedSubtitle = AudioLanguage.ENGLISH.value
 
         assertTrue(didUpdateSubtitleWasTriggered)
     }
@@ -314,7 +323,10 @@ class PlaybackTest {
     fun shouldNotTriggerEventAndChangeTrackWhenUnavailableSubtitleIsSet() {
         val playback = SomePlayback("valid-source.mp4")
 
-        playback.availableSubtitles += setOf("eng", "por")
+        playback.availableAudios += setOf(
+            AudioLanguage.ENGLISH.value,
+            AudioLanguage.PORTUGUESE.value
+        )
 
         playback.selectedSubtitle = "fr"
     }

--- a/clappr/src/test/kotlin/io/clappr/player/playback/ExoPlayerExtensionsTest.kt
+++ b/clappr/src/test/kotlin/io/clappr/player/playback/ExoPlayerExtensionsTest.kt
@@ -21,11 +21,9 @@ class ExoPlayerExtensionsTest {
 
     @Test
     fun `should load audio tracks`() {
-        val trackSelector = buildTrackSelector(
-            mapOf(
-                TRACK_TYPE_AUDIO to listOf("por"),
-                TRACK_TYPE_TEXT to listOf("eng")
-            )
+        val trackSelector = buildAvailableTracks(
+            TRACK_TYPE_AUDIO to listOf("por"),
+            TRACK_TYPE_TEXT to listOf("eng")
         )
 
         val expectedTracks = listOf(
@@ -37,11 +35,9 @@ class ExoPlayerExtensionsTest {
 
     @Test
     fun `should load subtitle tracks`() {
-        val trackSelector = buildTrackSelector(
-            mapOf(
-                TRACK_TYPE_AUDIO to listOf("por"),
-                TRACK_TYPE_TEXT to listOf("por", "eng")
-            )
+        val trackSelector = buildAvailableTracks(
+            TRACK_TYPE_AUDIO to listOf("por"),
+            TRACK_TYPE_TEXT to listOf("por", "eng")
         )
 
         val expectedTracks = listOf(
@@ -54,22 +50,20 @@ class ExoPlayerExtensionsTest {
 
     @Test
     fun `should load empty audio tracks when audio renderer is not setup`() {
-        val trackSelector = buildTrackSelector(emptyMap())
+        val trackSelector = buildAvailableTracks()
         assertEquals(emptyList(), trackSelector.audioTracks())
     }
 
     @Test
     fun `should load empty subtitle tracks when subtitle renderer is not setup`() {
-        val trackSelector = buildTrackSelector(emptyMap())
+        val trackSelector = buildAvailableTracks()
         assertEquals(emptyList(), trackSelector.subtitleTracks())
     }
 
     @Test
     fun `should load audio tracks with lowercase language`() {
-        val trackSelector = buildTrackSelector(
-            mapOf(
-                TRACK_TYPE_AUDIO to listOf("Por", "eNG")
-            )
+        val trackSelector = buildAvailableTracks(
+            TRACK_TYPE_AUDIO to listOf("Por", "eNG")
         )
 
         val expectedTracks = listOf(
@@ -82,10 +76,8 @@ class ExoPlayerExtensionsTest {
 
     @Test
     fun `should load subtitle tracks with lowercase language`() {
-        val trackSelector = buildTrackSelector(
-            mapOf(
-                TRACK_TYPE_TEXT to listOf("Por")
-            )
+        val trackSelector = buildAvailableTracks(
+            TRACK_TYPE_TEXT to listOf("Por")
         )
 
         val expectedTracks = listOf(
@@ -97,10 +89,8 @@ class ExoPlayerExtensionsTest {
 
     @Test
     fun `should load audio tracks with und language when language is null`() {
-        val trackSelector = buildTrackSelector(
-            mapOf(
-                TRACK_TYPE_AUDIO to listOf(null)
-            )
+        val trackSelector = buildAvailableTracks(
+            TRACK_TYPE_AUDIO to listOf(null)
         )
 
         val expectedTracks = listOf(
@@ -112,10 +102,8 @@ class ExoPlayerExtensionsTest {
 
     @Test
     fun `should load subtitle tracks with und language when language is null`() {
-        val trackSelector = buildTrackSelector(
-            mapOf(
-                TRACK_TYPE_TEXT to listOf(null)
-            )
+        val trackSelector = buildAvailableTracks(
+            TRACK_TYPE_TEXT to listOf(null)
         )
 
         val expectedTracks = listOf(
@@ -127,10 +115,8 @@ class ExoPlayerExtensionsTest {
 
     @Test
     fun `should load audio tracks with ISO 639-3 standard language for specific cases`() {
-        val trackSelector = buildTrackSelector(
-            mapOf(
-                TRACK_TYPE_AUDIO to listOf("original", "pt", "en")
-            )
+        val trackSelector = buildAvailableTracks(
+            TRACK_TYPE_AUDIO to listOf("original", "pt", "en")
         )
 
         val expectedTracks = listOf(
@@ -143,42 +129,8 @@ class ExoPlayerExtensionsTest {
     }
 
     @Test
-    fun `should return the selected audio language based on selected audio track`() {
-        val trackSelector = buildTrackSelector(
-            mapOf(
-                TRACK_TYPE_AUDIO to listOf("por", "eng", "und")
-            )
-        )
-
-        val player = mock<Player>()
-
-        val trackSelectionArray = buildTrackSelectionArray(trackSelector, TRACK_TYPE_AUDIO, 1)
-
-        whenever(player.currentTrackSelections).doReturn(trackSelectionArray)
-
-        assertEquals("eng", player.getSelectedAudio(trackSelector))
-    }
-
-    @Test
-    fun `should return the selected subtitle language based on selected subtitle track`() {
-        val trackSelector = buildTrackSelector(
-            mapOf(
-                TRACK_TYPE_TEXT to listOf("por", "eng")
-            )
-        )
-
-        val player = mock<Player>()
-
-        val trackSelectionArray = buildTrackSelectionArray(trackSelector, TRACK_TYPE_TEXT, 0)
-
-        whenever(player.currentTrackSelections).doReturn(trackSelectionArray)
-
-        assertEquals("por", player.getSelectedSubtitle(trackSelector))
-    }
-
-    @Test
     fun `should return the default audio language when there is no audios available`() {
-        val trackSelector = buildTrackSelector(emptyMap())
+        val trackSelector = buildAvailableTracks()
 
         val player = mock<Player>()
 
@@ -187,31 +139,52 @@ class ExoPlayerExtensionsTest {
 
     @Test
     fun `should return the default subtitle language when there is no subtitles available`() {
-        val trackSelector = buildTrackSelector(emptyMap())
+        val trackSelector = buildAvailableTracks()
 
         val player = mock<Player>()
 
         assertEquals("off", player.getSelectedSubtitle(trackSelector))
     }
 
-    private fun buildTrackSelectionArray(
-        trackSelector: MappingTrackSelector,
-        rendererType: Int,
-        selectedIndex: Int
-    ): TrackSelectionArray {
 
-        val rendererIndex = (0 until trackSelector.currentMappedTrackInfo!!.rendererCount)
-            .first { trackSelector.currentMappedTrackInfo!!.getRendererType(it) == rendererType }
+    @Test
+    fun `should return the selected audio language based on selected audio track`() {
+        val trackSelector = buildAvailableTracks(
+            TRACK_TYPE_AUDIO to listOf("por", "eng", "und")
+        )
 
-        val mappedTrackInfo = trackSelector.currentMappedTrackInfo!!
-        val trackGroupArray = mappedTrackInfo.getTrackGroups(rendererIndex)
-        val trackGroup = trackGroupArray.get(selectedIndex)
-        val trackSelection = FixedTrackSelection(trackGroup, 0)
+        val player = mock<Player>()
 
-        return TrackSelectionArray(trackSelection)
+        val trackSelections = buildSelectedTracks(
+            trackSelector,
+            TRACK_TYPE_AUDIO to "eng"
+        )
+
+        whenever(player.currentTrackSelections).doReturn(trackSelections)
+
+        assertEquals("eng", player.getSelectedAudio(trackSelector))
     }
 
-    private fun buildTrackSelector(rendererMap: Map<Int, List<String?>>): MappingTrackSelector {
+    @Test
+    fun `should return the selected subtitle language based on selected subtitle track`() {
+        val trackSelector = buildAvailableTracks(
+            TRACK_TYPE_TEXT to listOf("por", "eng")
+        )
+
+        val player = mock<Player>()
+
+        val trackSelections = buildSelectedTracks(
+            trackSelector,
+            TRACK_TYPE_TEXT to "por"
+        )
+
+        whenever(player.currentTrackSelections).doReturn(trackSelections)
+
+        assertEquals("por", player.getSelectedSubtitle(trackSelector))
+    }
+
+    private fun buildAvailableTracks(vararg renderers: Pair<Int, List<String?>>): MappingTrackSelector {
+        val rendererMap = renderers.toMap()
         val trackSelector = mock<DefaultTrackSelector>()
         val mappedTrackInfo = mock<MappingTrackSelector.MappedTrackInfo>()
 
@@ -219,23 +192,38 @@ class ExoPlayerExtensionsTest {
         whenever(mappedTrackInfo.rendererCount).thenReturn(rendererMap.size)
 
         rendererMap.keys.forEachIndexed { index, rendererType ->
-            whenever(mappedTrackInfo.getRendererType(index)).thenReturn(rendererType)
-        }
-
-        rendererMap.keys.forEachIndexed { index, rendererType ->
-
             val languages = rendererMap[rendererType].orEmpty()
-
             val formats = languages.map { createFormat(rendererType, it) }
-
             val trackGroups = formats.map { TrackGroup(it) }.toTypedArray()
-
             val trackGroupArray = TrackGroupArray(*trackGroups)
 
+            whenever(mappedTrackInfo.getRendererType(index)).thenReturn(rendererType)
             whenever(mappedTrackInfo.getTrackGroups(index)).thenReturn(trackGroupArray)
         }
 
         return trackSelector
+    }
+
+    private fun buildSelectedTracks(
+        trackSelector: MappingTrackSelector,
+        vararg selections: Pair<Int, String>
+    ): TrackSelectionArray {
+        val selectionMap = selections.toMap()
+        val mappedTrackInfo = trackSelector.currentMappedTrackInfo!!
+
+        val trackSelections = selectionMap.map { (rendererType, selectedLanguage) ->
+            val rendererIndex = (0 until mappedTrackInfo.rendererCount).first {
+                mappedTrackInfo.getRendererType(it) == rendererType
+            }
+            val trackGroupArray = mappedTrackInfo.getTrackGroups(rendererIndex)
+            val trackGroup = (0 until trackGroupArray.length)
+                .map { trackGroupArray.get(it) }
+                .first { it.getFormat(0).language == selectedLanguage }
+
+            FixedTrackSelection(trackGroup, 0)
+        }
+
+        return TrackSelectionArray(*trackSelections.toTypedArray())
     }
 
     private fun createFormat(renderType: Int, language: String?) = when (renderType) {

--- a/clappr/src/test/kotlin/io/clappr/player/playback/ExoPlayerExtensionsTest.kt
+++ b/clappr/src/test/kotlin/io/clappr/player/playback/ExoPlayerExtensionsTest.kt
@@ -1,0 +1,204 @@
+package io.clappr.player.playback
+
+import com.google.android.exoplayer2.C.TRACK_TYPE_AUDIO
+import com.google.android.exoplayer2.C.TRACK_TYPE_TEXT
+import com.google.android.exoplayer2.Format
+import com.google.android.exoplayer2.Player
+import com.google.android.exoplayer2.source.TrackGroup
+import com.google.android.exoplayer2.source.TrackGroupArray
+import com.google.android.exoplayer2.trackselection.DefaultTrackSelector
+import com.google.android.exoplayer2.trackselection.FixedTrackSelection
+import com.google.android.exoplayer2.trackselection.MappingTrackSelector
+import com.google.android.exoplayer2.trackselection.TrackSelectionArray
+import com.nhaarman.mockito_kotlin.doReturn
+import com.nhaarman.mockito_kotlin.mock
+import com.nhaarman.mockito_kotlin.whenever
+import org.junit.Test
+import kotlin.test.assertEquals
+
+
+class ExoPlayerExtensionsTest {
+
+    @Test
+    fun `should load audio tracks`() {
+        val trackSelector = buildTrackSelector(
+            mapOf(
+                TRACK_TYPE_AUDIO to listOf("por"),
+                TRACK_TYPE_TEXT to listOf("eng")
+            )
+        )
+
+        val expectedTracks = listOf(
+            TrackInfo(TRACK_TYPE_AUDIO, 0, 0, 0, "por")
+        )
+
+        assertEquals(expectedTracks, trackSelector.audioTracks())
+    }
+
+    @Test
+    fun `should load subtitle tracks`() {
+        val trackSelector = buildTrackSelector(
+            mapOf(
+                TRACK_TYPE_AUDIO to listOf("por"),
+                TRACK_TYPE_TEXT to listOf("por", "eng")
+            )
+        )
+
+        val expectedTracks = listOf(
+            TrackInfo(TRACK_TYPE_TEXT, 1, 0, 0, "por"),
+            TrackInfo(TRACK_TYPE_TEXT, 1, 1, 0, "eng")
+        )
+
+        assertEquals(expectedTracks, trackSelector.subtitleTracks())
+    }
+
+    @Test
+    fun `should load empty audio tracks when audio renderer is not setup`() {
+        val trackSelector = buildTrackSelector(emptyMap())
+        assertEquals(emptyList(), trackSelector.audioTracks())
+    }
+
+    @Test
+    fun `should load empty subtitle tracks when subtitle renderer is not setup`() {
+        val trackSelector = buildTrackSelector(emptyMap())
+        assertEquals(emptyList(), trackSelector.subtitleTracks())
+    }
+
+    @Test
+    fun `should load audio tracks with lowercase language`() {
+        val trackSelector = buildTrackSelector(
+            mapOf(
+                TRACK_TYPE_AUDIO to listOf("Por", "eNG")
+            )
+        )
+
+        val expectedTracks = listOf(
+            TrackInfo(TRACK_TYPE_AUDIO, 0, 0, 0, "por"),
+            TrackInfo(TRACK_TYPE_AUDIO, 0, 1, 0, "eng")
+        )
+
+        assertEquals(expectedTracks, trackSelector.audioTracks())
+    }
+
+    @Test
+    fun `should load subtitle tracks with lowercase language`() {
+        val trackSelector = buildTrackSelector(
+            mapOf(
+                TRACK_TYPE_TEXT to listOf("Por")
+            )
+        )
+
+        val expectedTracks = listOf(
+            TrackInfo(TRACK_TYPE_TEXT, 0, 0, 0, "por")
+        )
+
+        assertEquals(expectedTracks, trackSelector.subtitleTracks())
+    }
+
+    @Test
+    fun `should load audio tracks with und language when language is null`() {
+        val trackSelector = buildTrackSelector(
+            mapOf(
+                TRACK_TYPE_AUDIO to listOf(null)
+            )
+        )
+
+        val expectedTracks = listOf(
+            TrackInfo(TRACK_TYPE_AUDIO, 0, 0, 0, "und")
+        )
+
+        assertEquals(expectedTracks, trackSelector.audioTracks())
+    }
+
+    @Test
+    fun `should load subtitle tracks with und language when language is null`() {
+        val trackSelector = buildTrackSelector(
+            mapOf(
+                TRACK_TYPE_TEXT to listOf(null)
+            )
+        )
+
+        val expectedTracks = listOf(
+            TrackInfo(TRACK_TYPE_TEXT, 0, 0, 0, "off")
+        )
+
+        assertEquals(expectedTracks, trackSelector.subtitleTracks())
+    }
+
+    @Test
+    fun `should load audio tracks with ISO 639-3 standard language for specific cases`() {
+        val trackSelector = buildTrackSelector(
+            mapOf(
+                TRACK_TYPE_AUDIO to listOf("original", "pt", "en")
+            )
+        )
+
+        val expectedTracks = listOf(
+            TrackInfo(TRACK_TYPE_AUDIO, 0, 0, 0, "und"),
+            TrackInfo(TRACK_TYPE_AUDIO, 0, 1, 0, "por"),
+            TrackInfo(TRACK_TYPE_AUDIO, 0, 2, 0, "eng")
+        )
+
+        assertEquals(expectedTracks, trackSelector.audioTracks())
+    }
+
+    private fun buildTrackSelector(rendererMap: Map<Int, List<String?>>): MappingTrackSelector {
+        val trackSelector = mock<DefaultTrackSelector>()
+        val mappedTrackInfo = mock<MappingTrackSelector.MappedTrackInfo>()
+
+        whenever(trackSelector.currentMappedTrackInfo).thenReturn(mappedTrackInfo)
+        whenever(mappedTrackInfo.rendererCount).thenReturn(rendererMap.size)
+
+        rendererMap.keys.forEachIndexed { index, rendererType ->
+            whenever(mappedTrackInfo.getRendererType(index)).thenReturn(rendererType)
+        }
+
+        rendererMap.keys.forEachIndexed { index, rendererType ->
+
+            val languages = rendererMap[rendererType].orEmpty()
+
+            val formats = languages.map { createFormat(rendererType, it) }
+
+            val trackGroups = formats.map { TrackGroup(it) }.toTypedArray()
+
+            val trackGroupArray = TrackGroupArray(*trackGroups)
+
+            whenever(mappedTrackInfo.getTrackGroups(index)).thenReturn(trackGroupArray)
+        }
+
+        return trackSelector
+    }
+
+    private fun createFormat(renderType: Int, language: String?) = when (renderType) {
+        TRACK_TYPE_AUDIO -> createAudioFormat(language)
+        TRACK_TYPE_TEXT -> createTextFormat(language)
+        else -> createSampleFormat()
+    }
+
+    private fun createAudioFormat(language: String?) = Format.createAudioSampleFormat(
+        null,
+        null,
+        null,
+        0,
+        0,
+        0,
+        0,
+        null,
+        null,
+        0,
+        language
+    )
+
+    private fun createTextFormat(language: String?) = Format.createTextSampleFormat(
+        null,
+        null,
+        0,
+        language
+    )
+
+    private fun createSampleFormat() = Format.createSampleFormat(
+        null,
+        null,
+        0
+    )
+}

--- a/clappr/src/test/kotlin/io/clappr/player/playback/ExoPlayerExtensionsTest.kt
+++ b/clappr/src/test/kotlin/io/clappr/player/playback/ExoPlayerExtensionsTest.kt
@@ -142,6 +142,75 @@ class ExoPlayerExtensionsTest {
         assertEquals(expectedTracks, trackSelector.audioTracks())
     }
 
+    @Test
+    fun `should return the selected audio language based on selected audio track`() {
+        val trackSelector = buildTrackSelector(
+            mapOf(
+                TRACK_TYPE_AUDIO to listOf("por", "eng", "und")
+            )
+        )
+
+        val player = mock<Player>()
+
+        val trackSelectionArray = buildTrackSelectionArray(trackSelector, TRACK_TYPE_AUDIO, 1)
+
+        whenever(player.currentTrackSelections).doReturn(trackSelectionArray)
+
+        assertEquals("eng", player.getSelectedAudio(trackSelector))
+    }
+
+    @Test
+    fun `should return the selected subtitle language based on selected subtitle track`() {
+        val trackSelector = buildTrackSelector(
+            mapOf(
+                TRACK_TYPE_TEXT to listOf("por", "eng")
+            )
+        )
+
+        val player = mock<Player>()
+
+        val trackSelectionArray = buildTrackSelectionArray(trackSelector, TRACK_TYPE_TEXT, 0)
+
+        whenever(player.currentTrackSelections).doReturn(trackSelectionArray)
+
+        assertEquals("por", player.getSelectedSubtitle(trackSelector))
+    }
+
+    @Test
+    fun `should return the default audio language when there is no audios available`() {
+        val trackSelector = buildTrackSelector(emptyMap())
+
+        val player = mock<Player>()
+
+        assertEquals("", player.getSelectedAudio(trackSelector))
+    }
+
+    @Test
+    fun `should return the default subtitle language when there is no subtitles available`() {
+        val trackSelector = buildTrackSelector(emptyMap())
+
+        val player = mock<Player>()
+
+        assertEquals("off", player.getSelectedSubtitle(trackSelector))
+    }
+
+    private fun buildTrackSelectionArray(
+        trackSelector: MappingTrackSelector,
+        rendererType: Int,
+        selectedIndex: Int
+    ): TrackSelectionArray {
+
+        val rendererIndex = (0 until trackSelector.currentMappedTrackInfo!!.rendererCount)
+            .first { trackSelector.currentMappedTrackInfo!!.getRendererType(it) == rendererType }
+
+        val mappedTrackInfo = trackSelector.currentMappedTrackInfo!!
+        val trackGroupArray = mappedTrackInfo.getTrackGroups(rendererIndex)
+        val trackGroup = trackGroupArray.get(selectedIndex)
+        val trackSelection = FixedTrackSelection(trackGroup, 0)
+
+        return TrackSelectionArray(trackSelection)
+    }
+
     private fun buildTrackSelector(rendererMap: Map<Int, List<String?>>): MappingTrackSelector {
         val trackSelector = mock<DefaultTrackSelector>()
         val mappedTrackInfo = mock<MappingTrackSelector.MappedTrackInfo>()
@@ -175,30 +244,12 @@ class ExoPlayerExtensionsTest {
         else -> createSampleFormat()
     }
 
-    private fun createAudioFormat(language: String?) = Format.createAudioSampleFormat(
-        null,
-        null,
-        null,
-        0,
-        0,
-        0,
-        0,
-        null,
-        null,
-        0,
-        language
-    )
+    private fun createAudioFormat(language: String?) =
+        Format.createAudioSampleFormat(null, null, null, 0, 0, 0, 0, null, null, 0, language)
 
-    private fun createTextFormat(language: String?) = Format.createTextSampleFormat(
-        null,
-        null,
-        0,
-        language
-    )
+    private fun createTextFormat(language: String?) =
+        Format.createTextSampleFormat(null, null, 0, language)
 
-    private fun createSampleFormat() = Format.createSampleFormat(
-        null,
-        null,
-        0
-    )
+    private fun createSampleFormat() =
+        Format.createSampleFormat(null, null, 0)
 }

--- a/clappr/src/test/kotlin/io/clappr/player/playback/ExoPlayerExtensionsTest.kt
+++ b/clappr/src/test/kotlin/io/clappr/player/playback/ExoPlayerExtensionsTest.kt
@@ -134,7 +134,7 @@ class ExoPlayerExtensionsTest {
 
         val player = mock<Player>()
 
-        assertEquals("", player.getSelectedAudio(trackSelector))
+        assertEquals(null, player.getSelectedAudio(trackSelector))
     }
 
     @Test

--- a/clappr/src/test/kotlin/io/clappr/player/playback/ExoPlayerExtensionsTest.kt
+++ b/clappr/src/test/kotlin/io/clappr/player/playback/ExoPlayerExtensionsTest.kt
@@ -2,11 +2,7 @@ package io.clappr.player.playback
 
 import com.google.android.exoplayer2.C.TRACK_TYPE_AUDIO
 import com.google.android.exoplayer2.C.TRACK_TYPE_TEXT
-import com.google.android.exoplayer2.Format
 import com.google.android.exoplayer2.Player
-import com.google.android.exoplayer2.source.TrackGroup
-import com.google.android.exoplayer2.source.TrackGroupArray
-import com.google.android.exoplayer2.trackselection.DefaultTrackSelector
 import com.google.android.exoplayer2.trackselection.FixedTrackSelection
 import com.google.android.exoplayer2.trackselection.MappingTrackSelector
 import com.google.android.exoplayer2.trackselection.TrackSelectionArray
@@ -183,27 +179,6 @@ class ExoPlayerExtensionsTest {
         assertEquals("por", player.getSelectedSubtitle(trackSelector))
     }
 
-    private fun buildAvailableTracks(vararg renderers: Pair<Int, List<String?>>): MappingTrackSelector {
-        val rendererMap = renderers.toMap()
-        val trackSelector = mock<DefaultTrackSelector>()
-        val mappedTrackInfo = mock<MappingTrackSelector.MappedTrackInfo>()
-
-        whenever(trackSelector.currentMappedTrackInfo).thenReturn(mappedTrackInfo)
-        whenever(mappedTrackInfo.rendererCount).thenReturn(rendererMap.size)
-
-        rendererMap.keys.forEachIndexed { index, rendererType ->
-            val languages = rendererMap[rendererType].orEmpty()
-            val formats = languages.map { createFormat(rendererType, it) }
-            val trackGroups = formats.map { TrackGroup(it) }.toTypedArray()
-            val trackGroupArray = TrackGroupArray(*trackGroups)
-
-            whenever(mappedTrackInfo.getRendererType(index)).thenReturn(rendererType)
-            whenever(mappedTrackInfo.getTrackGroups(index)).thenReturn(trackGroupArray)
-        }
-
-        return trackSelector
-    }
-
     private fun buildSelectedTracks(
         trackSelector: MappingTrackSelector,
         vararg selections: Pair<Int, String>
@@ -225,19 +200,4 @@ class ExoPlayerExtensionsTest {
 
         return TrackSelectionArray(*trackSelections.toTypedArray())
     }
-
-    private fun createFormat(renderType: Int, language: String?) = when (renderType) {
-        TRACK_TYPE_AUDIO -> createAudioFormat(language)
-        TRACK_TYPE_TEXT -> createTextFormat(language)
-        else -> createSampleFormat()
-    }
-
-    private fun createAudioFormat(language: String?) =
-        Format.createAudioSampleFormat(null, null, null, 0, 0, 0, 0, null, null, 0, language)
-
-    private fun createTextFormat(language: String?) =
-        Format.createTextSampleFormat(null, null, 0, language)
-
-    private fun createSampleFormat() =
-        Format.createSampleFormat(null, null, 0)
 }

--- a/clappr/src/test/kotlin/io/clappr/player/playback/ExoPlayerPlaybackTest.kt
+++ b/clappr/src/test/kotlin/io/clappr/player/playback/ExoPlayerPlaybackTest.kt
@@ -2,14 +2,18 @@ package io.clappr.player.playback
 
 import androidx.test.core.app.ApplicationProvider
 import com.google.android.exoplayer2.C
+import com.google.android.exoplayer2.C.TRACK_TYPE_AUDIO
+import com.google.android.exoplayer2.C.TRACK_TYPE_TEXT
 import com.google.android.exoplayer2.Format
 import com.google.android.exoplayer2.Player.*
 import com.google.android.exoplayer2.source.MediaSourceEventListener
+import com.google.android.exoplayer2.trackselection.DefaultTrackSelector
 import com.nhaarman.mockito_kotlin.any
 import io.clappr.player.base.BaseObject
 import io.clappr.player.base.ClapprOption
 import io.clappr.player.base.Event.*
 import io.clappr.player.base.EventData.BITRATE
+import io.clappr.player.base.InternalEvent.DID_FIND_AUDIO
 import io.clappr.player.base.InternalEvent.DID_FIND_SUBTITLE
 import io.clappr.player.base.Options
 import io.clappr.player.bitrate.BitrateHistory
@@ -44,7 +48,11 @@ class ExoPlayerPlaybackTest {
         timeInNano = System.nanoTime()
         bitrateHistory = BitrateHistory { timeInNano }
         listenObject = BaseObject()
-        exoPlayerPlayBack = ExoPlayerPlayback(source = "aSource", options = Options(), bitrateHistory = bitrateHistory)
+        exoPlayerPlayBack = ExoPlayerPlayback(
+            source = "aSource",
+            options = Options(),
+            bitrateHistory = bitrateHistory
+        )
     }
 
     @Test
@@ -54,7 +62,10 @@ class ExoPlayerPlaybackTest {
             willSeekWasCalled = true
         }
         exoPlayerPlayBack.seekToLivePosition()
-        assertTrue("WILL_SEEK event wasn't triggered when seekToLivePosition() method was called", willSeekWasCalled)
+        assertTrue(
+            "WILL_SEEK event wasn't triggered when seekToLivePosition() method was called",
+            willSeekWasCalled
+        )
     }
 
     @Test
@@ -64,7 +75,10 @@ class ExoPlayerPlaybackTest {
             didSeekWasCalled = true
         }
         exoPlayerPlayBack.seekToLivePosition()
-        assertTrue("DID_SEEK event wasn't triggered when seekToLivePosition() method was called", didSeekWasCalled)
+        assertTrue(
+            "DID_SEEK event wasn't triggered when seekToLivePosition() method was called",
+            didSeekWasCalled
+        )
     }
 
     @Test
@@ -74,7 +88,10 @@ class ExoPlayerPlaybackTest {
             didUpdatePositionWasCalled = true
         }
         exoPlayerPlayBack.seekToLivePosition()
-        assertTrue("DID_UPDATE_POSITION event wasn't triggered when seekToLivePosition() method was called", didUpdatePositionWasCalled)
+        assertTrue(
+            "DID_UPDATE_POSITION event wasn't triggered when seekToLivePosition() method was called",
+            didUpdatePositionWasCalled
+        )
     }
 
     @Test
@@ -91,9 +108,12 @@ class ExoPlayerPlaybackTest {
     fun `Should return last reported bitrate`() {
         val expectedBitrate = 40L
 
-        exoPlayerPlayBack.ExoPlayerBitrateLogger().onLoadCompleted(null, null, addBitrateMediaLoadData(10))
-        exoPlayerPlayBack.ExoPlayerBitrateLogger().onLoadCompleted(null, null, addBitrateMediaLoadData(20))
-        exoPlayerPlayBack.ExoPlayerBitrateLogger().onLoadCompleted(null, null, addBitrateMediaLoadData(expectedBitrate))
+        exoPlayerPlayBack.ExoPlayerBitrateLogger()
+            .onLoadCompleted(null, null, addBitrateMediaLoadData(10))
+        exoPlayerPlayBack.ExoPlayerBitrateLogger()
+            .onLoadCompleted(null, null, addBitrateMediaLoadData(20))
+        exoPlayerPlayBack.ExoPlayerBitrateLogger()
+            .onLoadCompleted(null, null, addBitrateMediaLoadData(expectedBitrate))
 
         assertEquals(expectedBitrate, exoPlayerPlayBack.bitrate)
     }
@@ -103,13 +123,18 @@ class ExoPlayerPlaybackTest {
         val expectedBitrate = 40L
         var actualBitrate = 0L
 
-        val exoPlayerPlayback = ExoPlayerPlayback(source = "aSource", options = Options(), bitrateHistory = bitrateHistory)
+        val exoPlayerPlayback = ExoPlayerPlayback(
+            source = "aSource",
+            options = Options(),
+            bitrateHistory = bitrateHistory
+        )
 
         listenObject.listenTo(exoPlayerPlayback, DID_UPDATE_BITRATE.value) {
             actualBitrate = it?.getLong(BITRATE.value) ?: 0L
 
         }
-        exoPlayerPlayback.ExoPlayerBitrateLogger().onLoadCompleted(null, null, addBitrateMediaLoadData(expectedBitrate))
+        exoPlayerPlayback.ExoPlayerBitrateLogger()
+            .onLoadCompleted(null, null, addBitrateMediaLoadData(expectedBitrate))
 
         assertEquals(expectedBitrate, actualBitrate)
     }
@@ -119,8 +144,10 @@ class ExoPlayerPlaybackTest {
         var numberOfTriggers = 0
 
         listenObject.listenTo(exoPlayerPlayBack, DID_UPDATE_BITRATE.value) { numberOfTriggers++ }
-        exoPlayerPlayBack.ExoPlayerBitrateLogger().onLoadCompleted(null, null, addBitrateMediaLoadData(10))
-        exoPlayerPlayBack.ExoPlayerBitrateLogger().onLoadCompleted(null, null, addBitrateMediaLoadData(40))
+        exoPlayerPlayBack.ExoPlayerBitrateLogger()
+            .onLoadCompleted(null, null, addBitrateMediaLoadData(10))
+        exoPlayerPlayBack.ExoPlayerBitrateLogger()
+            .onLoadCompleted(null, null, addBitrateMediaLoadData(40))
 
         assertEquals(2, numberOfTriggers)
     }
@@ -131,8 +158,10 @@ class ExoPlayerPlaybackTest {
         var numberOfTriggers = 0
 
         listenObject.listenTo(exoPlayerPlayBack, DID_UPDATE_BITRATE.value) { numberOfTriggers++ }
-        exoPlayerPlayBack.ExoPlayerBitrateLogger().onLoadCompleted(null, null, addBitrateMediaLoadData(bitrate))
-        exoPlayerPlayBack.ExoPlayerBitrateLogger().onLoadCompleted(null, null, addBitrateMediaLoadData(bitrate))
+        exoPlayerPlayBack.ExoPlayerBitrateLogger()
+            .onLoadCompleted(null, null, addBitrateMediaLoadData(bitrate))
+        exoPlayerPlayBack.ExoPlayerBitrateLogger()
+            .onLoadCompleted(null, null, addBitrateMediaLoadData(bitrate))
 
         assertEquals(1, numberOfTriggers)
     }
@@ -145,7 +174,8 @@ class ExoPlayerPlaybackTest {
         listenObject.listenTo(exoPlayerPlayBack, DID_UPDATE_BITRATE.value) {
             didUpdateBitrateCalled = true
         }
-        exoPlayerPlayBack.ExoPlayerBitrateLogger().onLoadCompleted(null, null, addBitrateMediaLoadData(bitrate, C.TRACK_TYPE_AUDIO))
+        exoPlayerPlayBack.ExoPlayerBitrateLogger()
+            .onLoadCompleted(null, null, addBitrateMediaLoadData(bitrate, C.TRACK_TYPE_AUDIO))
 
         assertFalse(didUpdateBitrateCalled)
     }
@@ -167,14 +197,17 @@ class ExoPlayerPlaybackTest {
     fun `Should handle wrong time interval exception on add bitrate on history`() {
         timeInNano = -1
 
-        exoPlayerPlayBack.ExoPlayerBitrateLogger().onLoadCompleted(null, null, addBitrateMediaLoadData(20L))
+        exoPlayerPlayBack.ExoPlayerBitrateLogger()
+            .onLoadCompleted(null, null, addBitrateMediaLoadData(20L))
     }
 
     @Test
     fun `Should not trigger DID_UPDATE_BITRATE when video format is null`() {
         val videoFormatMock = null
-        val mediaLoadData = MediaSourceEventListener.MediaLoadData(0, C.TRACK_TYPE_DEFAULT, videoFormatMock, 0,
-                null, 0L, 0L)
+        val mediaLoadData = MediaSourceEventListener.MediaLoadData(
+            0, C.TRACK_TYPE_DEFAULT, videoFormatMock, 0,
+            null, 0L, 0L
+        )
         var didUpdateBitrateCalled = false
 
         listenObject.listenTo(exoPlayerPlayBack, DID_UPDATE_BITRATE.value) {
@@ -193,7 +226,8 @@ class ExoPlayerPlaybackTest {
         listenObject.listenTo(exoPlayerPlayBack, DID_UPDATE_BITRATE.value) {
             didUpdateBitrateCalled = true
         }
-        exoPlayerPlayBack.ExoPlayerBitrateLogger().onLoadCompleted(null, null, addBitrateMediaLoadData(bitrate, C.TRACK_TYPE_DEFAULT))
+        exoPlayerPlayBack.ExoPlayerBitrateLogger()
+            .onLoadCompleted(null, null, addBitrateMediaLoadData(bitrate, C.TRACK_TYPE_DEFAULT))
 
         assertTrue(didUpdateBitrateCalled)
     }
@@ -206,7 +240,8 @@ class ExoPlayerPlaybackTest {
         listenObject.listenTo(exoPlayerPlayBack, DID_UPDATE_BITRATE.value) {
             didUpdateBitrateCalled = true
         }
-        exoPlayerPlayBack.ExoPlayerBitrateLogger().onLoadCompleted(null, null, addBitrateMediaLoadData(bitrate, C.TRACK_TYPE_VIDEO))
+        exoPlayerPlayBack.ExoPlayerBitrateLogger()
+            .onLoadCompleted(null, null, addBitrateMediaLoadData(bitrate, C.TRACK_TYPE_VIDEO))
 
         assertTrue(didUpdateBitrateCalled)
     }
@@ -600,11 +635,82 @@ class ExoPlayerPlaybackTest {
         )
     }
 
-    private fun addBitrateMediaLoadData(bitrate: Long, trackType: Int = C.TRACK_TYPE_DEFAULT): MediaSourceEventListener.MediaLoadData {
-        val videoFormatMock = Format.createVideoSampleFormat(null, null, null, bitrate.toInt(),
-                0, 0, 0, 0f, listOf<ByteArray>(), null)
+    @Test
+    fun `Should trigger DID_FIND_AUDIO when ExoPlayer load default audios`() {
+        val source = "supported-source.mp4"
+        var eventCalled = false
 
-        return MediaSourceEventListener.MediaLoadData(0, trackType, videoFormatMock,
-                0, null, 0L, 0L)
+        val trackSelector = buildAvailableTracks(
+            TRACK_TYPE_AUDIO to listOf(
+                AudioLanguage.PORTUGUESE.value,
+                AudioLanguage.ENGLISH.value
+            )
+        ) as DefaultTrackSelector
+
+        exoPlayerPlayBack = ExoPlayerPlayback(
+            source = source,
+            createDefaultTrackSelector = { trackSelector }
+        )
+
+        exoPlayerPlayBack.load(source = source)
+
+        listenObject.listenTo(exoPlayerPlayBack, DID_FIND_AUDIO.value) {
+            eventCalled = true
+        }
+
+        exoPlayerPlayBack.eventsListener.onLoadingChanged(true)
+        exoPlayerPlayBack.eventsListener.onPlayerStateChanged(false, STATE_READY)
+
+        assertTrue(
+            "DID_FIND_AUDIO event wasn't triggered when setupBuiltInAudios method was called",
+            eventCalled
+        )
+    }
+
+    @Test
+    fun `Should trigger DID_FIND_SUBTITLE when ExoPlayer load default subtitles`() {
+        val source = "supported-source.mp4"
+        var eventCalled = false
+
+        val trackSelector = buildAvailableTracks(
+            TRACK_TYPE_TEXT to listOf(
+                AudioLanguage.PORTUGUESE.value,
+                AudioLanguage.ENGLISH.value
+            )
+        ) as DefaultTrackSelector
+
+        exoPlayerPlayBack = ExoPlayerPlayback(
+            source = source,
+            createDefaultTrackSelector = { trackSelector }
+        )
+
+        exoPlayerPlayBack.load(source = source)
+
+        listenObject.listenTo(exoPlayerPlayBack, DID_FIND_SUBTITLE.value) {
+            eventCalled = true
+        }
+
+        exoPlayerPlayBack.eventsListener.onLoadingChanged(true)
+        exoPlayerPlayBack.eventsListener.onPlayerStateChanged(false, STATE_READY)
+
+        assertTrue(
+            "DID_FIND_SUBTITLE event wasn't triggered when setupBuiltInAudios method was called",
+            eventCalled
+        )
+    }
+
+    private fun addBitrateMediaLoadData(
+        bitrate: Long,
+        trackType: Int = C.TRACK_TYPE_DEFAULT
+    ): MediaSourceEventListener.MediaLoadData {
+        val videoFormatMock = Format.createVideoSampleFormat(
+            null, null, null, bitrate.toInt(),
+            0, 0, 0, 0f, listOf<ByteArray>(), null
+        )
+
+        return MediaSourceEventListener.MediaLoadData(
+            0, trackType, videoFormatMock,
+            0, null, 0L, 0L
+        )
     }
 }

--- a/clappr/src/test/kotlin/io/clappr/player/playback/ExoPlayerPlaybackTest.kt
+++ b/clappr/src/test/kotlin/io/clappr/player/playback/ExoPlayerPlaybackTest.kt
@@ -4,11 +4,11 @@ import androidx.test.core.app.ApplicationProvider
 import com.google.android.exoplayer2.C
 import com.google.android.exoplayer2.C.TRACK_TYPE_AUDIO
 import com.google.android.exoplayer2.C.TRACK_TYPE_TEXT
+import com.google.android.exoplayer2.ExoPlaybackException
 import com.google.android.exoplayer2.Format
 import com.google.android.exoplayer2.Player.*
 import com.google.android.exoplayer2.source.MediaSourceEventListener
 import com.google.android.exoplayer2.trackselection.DefaultTrackSelector
-import com.nhaarman.mockito_kotlin.any
 import io.clappr.player.base.BaseObject
 import io.clappr.player.base.ClapprOption
 import io.clappr.player.base.Event.*
@@ -30,6 +30,7 @@ import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 import org.robolectric.shadows.ShadowLog
+import java.io.IOException
 import kotlin.test.assertEquals
 
 @RunWith(RobolectricTestRunner::class)
@@ -175,7 +176,7 @@ class ExoPlayerPlaybackTest {
             didUpdateBitrateCalled = true
         }
         exoPlayerPlayBack.ExoPlayerBitrateLogger()
-            .onLoadCompleted(null, null, addBitrateMediaLoadData(bitrate, C.TRACK_TYPE_AUDIO))
+            .onLoadCompleted(null, null, addBitrateMediaLoadData(bitrate, TRACK_TYPE_AUDIO))
 
         assertFalse(didUpdateBitrateCalled)
     }
@@ -429,7 +430,7 @@ class ExoPlayerPlaybackTest {
             eventCalled = true
         }
 
-        exoPlayerPlayBack.eventsListener.onPlayerStateChanged(any(), STATE_ENDED)
+        exoPlayerPlayBack.eventsListener.onPlayerStateChanged(true, STATE_ENDED)
 
         assertEquals(State.IDLE, exoPlayerPlayBack.state)
         assertTrue(
@@ -450,7 +451,7 @@ class ExoPlayerPlaybackTest {
         }
 
         exoPlayerPlayBack.eventsListener.onPlayerStateChanged(false, STATE_READY)
-        exoPlayerPlayBack.eventsListener.onPlayerStateChanged(any(), STATE_BUFFERING)
+        exoPlayerPlayBack.eventsListener.onPlayerStateChanged(true, STATE_BUFFERING)
 
         assertEquals(State.STALLING, exoPlayerPlayBack.state)
         assertTrue(
@@ -552,7 +553,8 @@ class ExoPlayerPlaybackTest {
             eventCalled = true
         }
 
-        exoPlayerPlayBack.eventsListener.onPlayerError(any())
+        val exception = ExoPlaybackException.createForSource(IOException())
+        exoPlayerPlayBack.eventsListener.onPlayerError(exception)
 
         assertEquals(State.ERROR, exoPlayerPlayBack.state)
         assertTrue(

--- a/clappr/src/test/kotlin/io/clappr/player/playback/ExoPlayerPlaybackTest.kt
+++ b/clappr/src/test/kotlin/io/clappr/player/playback/ExoPlayerPlaybackTest.kt
@@ -379,7 +379,7 @@ class ExoPlayerPlaybackTest {
         assertEquals(State.IDLE, exoPlayerPlayBack.state)
         assertEquals(mutableSetOf(), exoPlayerPlayBack.availableAudios)
         assertEquals(mutableSetOf(), exoPlayerPlayBack.availableSubtitles)
-        assertEquals(AudioLanguage.UNSET.value, exoPlayerPlayBack.selectedAudio)
+        assertEquals(null, exoPlayerPlayBack.selectedAudio)
         assertEquals(SubtitleLanguage.OFF.value, exoPlayerPlayBack.selectedSubtitle)
     }
 

--- a/clappr/src/test/kotlin/io/clappr/player/playback/ExoPlayerPlaybackTest.kt
+++ b/clappr/src/test/kotlin/io/clappr/player/playback/ExoPlayerPlaybackTest.kt
@@ -6,8 +6,6 @@ import com.google.android.exoplayer2.Format
 import com.google.android.exoplayer2.Player
 import com.google.android.exoplayer2.source.MediaSourceEventListener
 import io.clappr.player.base.BaseObject
-import io.clappr.player.base.ClapprOption.DEFAULT_AUDIO
-import io.clappr.player.base.ClapprOption.DEFAULT_SUBTITLE
 import io.clappr.player.base.Event.*
 import io.clappr.player.base.EventData.BITRATE
 import io.clappr.player.base.Options

--- a/clappr/src/test/kotlin/io/clappr/player/playback/ExoPlayerPlaybackTest.kt
+++ b/clappr/src/test/kotlin/io/clappr/player/playback/ExoPlayerPlaybackTest.kt
@@ -15,6 +15,8 @@ import io.clappr.player.base.Event.*
 import io.clappr.player.base.EventData.BITRATE
 import io.clappr.player.base.InternalEvent.DID_FIND_AUDIO
 import io.clappr.player.base.InternalEvent.DID_FIND_SUBTITLE
+import io.clappr.player.base.InternalEventData
+import io.clappr.player.base.InternalEventData.*
 import io.clappr.player.base.Options
 import io.clappr.player.bitrate.BitrateHistory
 import io.clappr.player.components.AudioLanguage
@@ -640,7 +642,7 @@ class ExoPlayerPlaybackTest {
     @Test
     fun `Should trigger DID_FIND_AUDIO when ExoPlayer load default audios`() {
         val source = "supported-source.mp4"
-        var eventCalled = false
+        var foundAudios: List<String>? = null
 
         val trackSelector = buildAvailableTracks(
             TRACK_TYPE_AUDIO to listOf(
@@ -657,27 +659,29 @@ class ExoPlayerPlaybackTest {
         exoPlayerPlayBack.load(source = source)
 
         listenObject.listenTo(exoPlayerPlayBack, DID_FIND_AUDIO.value) {
-            eventCalled = true
+            foundAudios = it!!.getStringArrayList(FOUND_AUDIOS.value)
         }
 
         exoPlayerPlayBack.eventsListener.onLoadingChanged(true)
         exoPlayerPlayBack.eventsListener.onPlayerStateChanged(false, STATE_READY)
 
-        assertTrue(
-            "DID_FIND_AUDIO event wasn't triggered when setupBuiltInAudios method was called",
-            eventCalled
+        val expectedAudios = listOf(
+            AudioLanguage.PORTUGUESE.value,
+            AudioLanguage.ENGLISH.value
         )
+
+        assertEquals(expectedAudios, foundAudios)
     }
 
     @Test
     fun `Should trigger DID_FIND_SUBTITLE when ExoPlayer load default subtitles`() {
         val source = "supported-source.mp4"
-        var eventCalled = false
+        var foundSubtitles: List<String>? = null
 
         val trackSelector = buildAvailableTracks(
             TRACK_TYPE_TEXT to listOf(
-                AudioLanguage.PORTUGUESE.value,
-                AudioLanguage.ENGLISH.value
+                SubtitleLanguage.OFF.value,
+                SubtitleLanguage.PORTUGUESE.value
             )
         ) as DefaultTrackSelector
 
@@ -689,16 +693,18 @@ class ExoPlayerPlaybackTest {
         exoPlayerPlayBack.load(source = source)
 
         listenObject.listenTo(exoPlayerPlayBack, DID_FIND_SUBTITLE.value) {
-            eventCalled = true
+            foundSubtitles = it!!.getStringArrayList(FOUND_SUBTITLES.value)
         }
 
         exoPlayerPlayBack.eventsListener.onLoadingChanged(true)
         exoPlayerPlayBack.eventsListener.onPlayerStateChanged(false, STATE_READY)
 
-        assertTrue(
-            "DID_FIND_SUBTITLE event wasn't triggered when setupBuiltInAudios method was called",
-            eventCalled
+        val expectedSubtitles = listOf(
+            SubtitleLanguage.OFF.value,
+            SubtitleLanguage.PORTUGUESE.value
         )
+
+        assertEquals(expectedSubtitles, foundSubtitles)
     }
 
     private fun addBitrateMediaLoadData(

--- a/clappr/src/test/kotlin/io/clappr/player/playback/ExoPlayerUtil.kt
+++ b/clappr/src/test/kotlin/io/clappr/player/playback/ExoPlayerUtil.kt
@@ -1,0 +1,46 @@
+package io.clappr.player.playback
+
+import com.google.android.exoplayer2.C
+import com.google.android.exoplayer2.Format
+import com.google.android.exoplayer2.source.TrackGroup
+import com.google.android.exoplayer2.source.TrackGroupArray
+import com.google.android.exoplayer2.trackselection.DefaultTrackSelector
+import com.google.android.exoplayer2.trackselection.MappingTrackSelector
+import com.nhaarman.mockito_kotlin.mock
+import com.nhaarman.mockito_kotlin.whenever
+
+fun buildAvailableTracks(vararg renderers: Pair<Int, List<String?>>): MappingTrackSelector {
+    val rendererMap = renderers.toMap()
+    val trackSelector = mock<DefaultTrackSelector>()
+    val mappedTrackInfo = mock<MappingTrackSelector.MappedTrackInfo>()
+
+    whenever(trackSelector.currentMappedTrackInfo).thenReturn(mappedTrackInfo)
+    whenever(mappedTrackInfo.rendererCount).thenReturn(rendererMap.size)
+
+    rendererMap.keys.forEachIndexed { index, rendererType ->
+        val languages = rendererMap[rendererType].orEmpty()
+        val formats = languages.map { createFormat(rendererType, it) }
+        val trackGroups = formats.map { TrackGroup(it) }.toTypedArray()
+        val trackGroupArray = TrackGroupArray(*trackGroups)
+
+        whenever(mappedTrackInfo.getRendererType(index)).thenReturn(rendererType)
+        whenever(mappedTrackInfo.getTrackGroups(index)).thenReturn(trackGroupArray)
+    }
+
+    return trackSelector
+}
+
+private fun createFormat(renderType: Int, language: String?) = when (renderType) {
+    C.TRACK_TYPE_AUDIO -> createAudioFormat(language)
+    C.TRACK_TYPE_TEXT -> createTextFormat(language)
+    else -> createSampleFormat()
+}
+
+private fun createAudioFormat(language: String?) =
+    Format.createAudioSampleFormat(null, null, null, 0, 0, 0, 0, null, null, 0, language)
+
+private fun createTextFormat(language: String?) =
+    Format.createTextSampleFormat(null, null, 0, language)
+
+private fun createSampleFormat() =
+    Format.createSampleFormat(null, null, 0)

--- a/clappr/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/clappr/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,2 @@
+mock-maker-inline
+


### PR DESCRIPTION
### Goal
This PR removes all `MediaOptions` dependency. 

This should make easier to handle:
- Available audios and subtitles 
- Selected audio and subtitle

### How to test
1 - run player unit tests: .`/gradlew clean test`