### PR TITLE
Fix Media Control Blinking Animations

### DIFF
--- a/clappr/src/main/kotlin/io/clappr/player/plugin/control/MediaControl.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/plugin/control/MediaControl.kt
@@ -366,20 +366,23 @@ open class MediaControl(core: Core, pluginName: String = name) : UICorePlugin(co
     }
 
     override fun hide() {
-        hideAnimationEnded = false
-
         if (isEnabled && isPlaybackIdle) return
+
+        hideAnimationEnded = false
 
         core.trigger(InternalEvent.WILL_HIDE_MEDIA_CONTROL.value)
 
-        animateFadeOut(view) {
-            hideMediaControlElements()
-            hideDefaultMediaControlPanels()
-            hideModalPanel()
-            hideAnimationEnded = true
+        if (isVisible) animateFadeOut(view) { hideMediaControl() }
+        else hideMediaControl()
+    }
 
-            core.trigger(InternalEvent.DID_HIDE_MEDIA_CONTROL.value)
-        }
+    private fun hideMediaControl() {
+        hideMediaControlElements()
+        hideDefaultMediaControlPanels()
+        hideModalPanel()
+        hideAnimationEnded = true
+
+        core.trigger(InternalEvent.DID_HIDE_MEDIA_CONTROL.value)
     }
 
     override fun show() {

--- a/clappr/src/main/kotlin/io/clappr/player/plugin/control/MediaControl.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/plugin/control/MediaControl.kt
@@ -155,8 +155,7 @@ open class MediaControl(core: Core, pluginName: String = name) : UICorePlugin(co
         updateInteractionTime()
 
         if (!isPlaybackIdle && duration > 0) {
-            handler.removeCallbacksAndMessages(null)
-            hideDelayed(duration)
+            hideDelayedWithCleanHandler(duration)
         }
 
         core.trigger(InternalEvent.DID_SHOW_MEDIA_CONTROL.value)
@@ -251,6 +250,11 @@ open class MediaControl(core: Core, pluginName: String = name) : UICorePlugin(co
     private fun showMediaControlElements() {
         visibility = Visibility.VISIBLE
         backgroundView.visibility = View.VISIBLE
+    }
+
+    private fun hideDelayedWithCleanHandler(duration: Long) {
+        handler.removeCallbacksAndMessages(null)
+        hideDelayed(duration)
     }
 
     private fun hideDelayed(duration: Long) {

--- a/clappr/src/main/kotlin/io/clappr/player/plugin/control/MediaControl.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/plugin/control/MediaControl.kt
@@ -155,6 +155,7 @@ open class MediaControl(core: Core, pluginName: String = name) : UICorePlugin(co
         updateInteractionTime()
 
         if (!isPlaybackIdle && duration > 0) {
+            handler.removeCallbacksAndMessages(null)
             hideDelayed(duration)
         }
 

--- a/clappr/src/main/kotlin/io/clappr/player/plugin/control/MediaControl.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/plugin/control/MediaControl.kt
@@ -293,9 +293,11 @@ open class MediaControl(core: Core, pluginName: String = name) : UICorePlugin(co
     }
 
     private fun closeModal() {
-        if (modalPanelIsOpen()) showDefaultMediaControlPanels()
+        if (modalPanelIsOpen()) {
+            showDefaultMediaControlPanels()
+            animateFadeOut(modalPanel) { hideModalPanel() }
+        } else hideModalPanel()
 
-        animateFadeOut(modalPanel) { hideModalPanel() }
         core.trigger(InternalEvent.DID_CLOSE_MODAL_PANEL.value)
     }
 


### PR DESCRIPTION
Goal
---

In some specific situations Media Control animations do not behave as they should and flash rapidly. This occur in two scenarios:

1. The problem occurs when the Modal tries to hide it self even though it is not open at the beginning of the video. The animation changes the alpha of the component that appears briefly on the screen and then hides again.
2. The problem is due to using `postDelayed` to hide Media Control after a delay. When Media Control is opened a new post is performed to close it, if this operation is performed several times in sequence in a short period of time the old posts are executed at an unexpected time. The `postDelayed` performs Media Control's hide animation that alters the component's alpha so that appears briefly on the screen and then hides again

Reproducing the problem
---

Go to `dev` branch

#### Scenario 1

1. Go to sample app and load a video
2. Check in the first loading of the video that the media control flashes

#### Scenario 2

1. Go to sample app and load a video
2. Click in the video to show the Media Control and again to hide the Media Control several times
3. Open the Media Control one last time
4. The Media Control will start to flash

After the fix
---

Go to `fix/media_control_animations` branch

#### Scenario 1

1. Go to sample app and load a video
2. Check in the first loading of the video that the media control not flashes

#### Scenario 2

1. Go to sample app and load a video
2. Click in the video to show the Media Control and again to hide the Media Control several times
3. Check the Media Control will not flash