### PR TITLE
Handle media control visibilty when video stop playing

### DIFF
--- a/clappr/src/main/kotlin/io/clappr/player/extensions/BundleExtensions.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/extensions/BundleExtensions.kt
@@ -1,0 +1,16 @@
+package io.clappr.player.extensions
+
+import android.os.Bundle
+import io.clappr.player.base.EventData
+import io.clappr.player.base.keys.Action
+import io.clappr.player.base.keys.Key
+
+fun Bundle.extractInputKey(): Pair<Key, Action> {
+    val keyCode = getString(EventData.INPUT_KEY_CODE.value).orEmpty()
+    val keyAction = getString(EventData.INPUT_KEY_ACTION.value).orEmpty()
+
+    val key = Key.getByValue(keyCode) ?: Key.UNDEFINED
+    val action = Action.getByValue(keyAction) ?: Action.UNDEFINED
+
+    return key to action
+}

--- a/clappr/src/main/kotlin/io/clappr/player/extensions/BundleExtensions.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/extensions/BundleExtensions.kt
@@ -5,12 +5,17 @@ import io.clappr.player.base.EventData
 import io.clappr.player.base.keys.Action
 import io.clappr.player.base.keys.Key
 
-fun Bundle.extractInputKey(): Pair<Key, Action> {
+data class InputKey(val key: Key, val action: Action)
+
+fun Bundle.extractInputKey(): InputKey? {
     val keyCode = getString(EventData.INPUT_KEY_CODE.value).orEmpty()
     val keyAction = getString(EventData.INPUT_KEY_ACTION.value).orEmpty()
 
-    val key = Key.getByValue(keyCode) ?: Key.UNDEFINED
-    val action = Action.getByValue(keyAction) ?: Action.UNDEFINED
+    val key = Key.getByValue(keyCode)
+    val action = Action.getByValue(keyAction)
 
-    return key to action
+    return when {
+        key != null && action != null -> InputKey(key, action)
+        else -> null
+    }
 }

--- a/clappr/src/main/kotlin/io/clappr/player/plugin/control/MediaControl.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/plugin/control/MediaControl.kt
@@ -331,9 +331,11 @@ open class MediaControl(core: Core, pluginName: String = name) :
     }
 
     private fun onInputReceived(bundle: Bundle?) {
-        bundle?.let {
-            val (key, action) = it.extractInputKey()
+        bundle?.let { handleInputKey(it) }
+    }
 
+    private fun handleInputKey(bundle: Bundle) {
+        bundle.extractInputKey()?.apply {
             if (isValidActivationKey(key) && action == Action.UP) {
                 when (isVisible) {
                     true -> if (navigationKeys.contains(key)) updateInteractionTime()

--- a/clappr/src/main/kotlin/io/clappr/player/plugin/control/MediaControl.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/plugin/control/MediaControl.kt
@@ -18,6 +18,7 @@ import io.clappr.player.base.keys.Key
 import io.clappr.player.components.Core
 import io.clappr.player.components.Playback
 import io.clappr.player.extensions.animate
+import io.clappr.player.extensions.extractInputKey
 import io.clappr.player.plugin.Plugin.State
 import io.clappr.player.plugin.PluginEntry
 import io.clappr.player.plugin.UIPlugin.Visibility
@@ -331,10 +332,7 @@ open class MediaControl(core: Core, pluginName: String = name) :
 
     private fun onInputReceived(bundle: Bundle?) {
         bundle?.let {
-            val keyCode = it.getString(EventData.INPUT_KEY_CODE.value) ?: ""
-            val keyAction = it.getString(EventData.INPUT_KEY_ACTION.value) ?: ""
-            val key = Key.getByValue(keyCode) ?: Key.UNDEFINED
-            val action = Action.getByValue(keyAction)
+            val (key, action) = it.extractInputKey()
 
             if (isValidActivationKey(key) && action == Action.UP) {
                 when (isVisible) {

--- a/clappr/src/main/kotlin/io/clappr/player/plugin/control/MediaControl.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/plugin/control/MediaControl.kt
@@ -54,8 +54,8 @@ open class MediaControl(core: Core, pluginName: String = name) :
         val entry = PluginEntry.Core(name = name, factory = { core -> MediaControl(core) })
     }
 
-    protected val defaultShowDuration = 300L
-    protected val longShowDuration = 3000L
+    private val defaultShowDuration = 300L
+    private val longShowDuration = 3000L
 
     private val handler = Handler()
 
@@ -286,7 +286,7 @@ open class MediaControl(core: Core, pluginName: String = name) :
         }, duration)
     }
 
-    protected fun updateInteractionTime() {
+    private fun updateInteractionTime() {
         lastInteractionTime = SystemClock.elapsedRealtime()
     }
 

--- a/clappr/src/main/kotlin/io/clappr/player/plugin/control/MediaControl.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/plugin/control/MediaControl.kt
@@ -162,7 +162,7 @@ open class MediaControl(core: Core, pluginName: String = name) :
     private fun setupShowDuration(duration: Long) {
         updateInteractionTime()
 
-        if (!isPlaybackIdle && duration > 0) {
+        if (duration > 0) {
             hideDelayedWithCleanHandler(duration)
         }
 

--- a/clappr/src/main/kotlin/io/clappr/player/plugin/control/MediaControl.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/plugin/control/MediaControl.kt
@@ -211,7 +211,7 @@ open class MediaControl(core: Core, pluginName: String = name) :
     private fun setupPlugins() {
         controlPlugins.clear()
 
-        with(core.plugins.filterIsInstance(MediaControl.Plugin::class.java)) {
+        with(core.plugins.filterIsInstance(Plugin::class.java)) {
             core.options[ClapprOption.MEDIA_CONTROL_PLUGINS.value]?.let {
                 controlPlugins.addAll(orderedPlugins(this, it.toString()))
             } ?: controlPlugins.addAll(this)

--- a/clappr/src/test/kotlin/io/clappr/player/extensions/BundleExtensionsTest.kt
+++ b/clappr/src/test/kotlin/io/clappr/player/extensions/BundleExtensionsTest.kt
@@ -1,0 +1,52 @@
+package io.clappr.player.extensions
+
+import android.os.Bundle
+import com.nhaarman.mockitokotlin2.doReturn
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.whenever
+import io.clappr.player.base.EventData
+import io.clappr.player.base.keys.Action
+import io.clappr.player.base.keys.Key
+import org.junit.Test
+import kotlin.test.assertEquals
+
+class BundleExtensionsTest {
+    @Test
+    fun `should extract key and action from bundle`() {
+        val bundle = mock<Bundle>()
+
+        whenever(bundle.getString(EventData.INPUT_KEY_CODE.value)) doReturn Key.BACK.value
+        whenever(bundle.getString(EventData.INPUT_KEY_ACTION.value)) doReturn Action.UP.value
+
+        val (key, action) = bundle.extractInputKey()
+
+        assertEquals(Key.BACK, key)
+        assertEquals(Action.UP, action)
+    }
+
+    @Test
+    fun `should return undefined key and action when there is no key and action available`() {
+        val bundle = mock<Bundle>()
+
+        whenever(bundle.getString(EventData.INPUT_KEY_CODE.value)) doReturn null
+        whenever(bundle.getString(EventData.INPUT_KEY_ACTION.value)) doReturn null
+
+        val (key, action) = bundle.extractInputKey()
+
+        assertEquals(Key.UNDEFINED, key)
+        assertEquals(Action.UNDEFINED, action)
+    }
+
+    @Test
+    fun `should return undefined key and action when the key and action are not mapped`() {
+        val bundle = mock<Bundle>()
+
+        whenever(bundle.getString(EventData.INPUT_KEY_CODE.value)) doReturn "unknown"
+        whenever(bundle.getString(EventData.INPUT_KEY_ACTION.value)) doReturn "unknown"
+
+        val (key, action) = bundle.extractInputKey()
+
+        assertEquals(Key.UNDEFINED, key)
+        assertEquals(Action.UNDEFINED, action)
+    }
+}

--- a/clappr/src/test/kotlin/io/clappr/player/extensions/BundleExtensionsTest.kt
+++ b/clappr/src/test/kotlin/io/clappr/player/extensions/BundleExtensionsTest.kt
@@ -26,24 +26,26 @@ class BundleExtensionsTest {
     }
 
     @Test
-    fun `should return null key and action when there is no key available`() {
+    fun `should return null when there is no key available`() {
         val bundle = mock<Bundle>()
 
         whenever(bundle.getString(EventData.INPUT_KEY_CODE.value)) doReturn null
+        whenever(bundle.getString(EventData.INPUT_KEY_ACTION.value)) doReturn Action.UP.value
 
         val inputKey = bundle.extractInputKey()
 
-        assertNull(inputKey?.key)
+        assertNull(inputKey)
     }
 
     @Test
-    fun `should return null action when the action are not mapped`() {
+    fun `should return null when there is no action available`() {
         val bundle = mock<Bundle>()
 
+        whenever(bundle.getString(EventData.INPUT_KEY_CODE.value)) doReturn Key.BACK.value
         whenever(bundle.getString(EventData.INPUT_KEY_ACTION.value)) doReturn null
 
         val inputKey = bundle.extractInputKey()
 
-        assertNull(inputKey?.action)
+        assertNull(inputKey)
     }
 }

--- a/clappr/src/test/kotlin/io/clappr/player/extensions/BundleExtensionsTest.kt
+++ b/clappr/src/test/kotlin/io/clappr/player/extensions/BundleExtensionsTest.kt
@@ -9,6 +9,7 @@ import io.clappr.player.base.keys.Action
 import io.clappr.player.base.keys.Key
 import org.junit.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNull
 
 class BundleExtensionsTest {
     @Test
@@ -18,35 +19,31 @@ class BundleExtensionsTest {
         whenever(bundle.getString(EventData.INPUT_KEY_CODE.value)) doReturn Key.BACK.value
         whenever(bundle.getString(EventData.INPUT_KEY_ACTION.value)) doReturn Action.UP.value
 
-        val (key, action) = bundle.extractInputKey()
+        val inputKey = bundle.extractInputKey()
 
-        assertEquals(Key.BACK, key)
-        assertEquals(Action.UP, action)
+        assertEquals(Key.BACK, inputKey?.key)
+        assertEquals(Action.UP, inputKey?.action)
     }
 
     @Test
-    fun `should return undefined key and action when there is no key and action available`() {
+    fun `should return null key and action when there is no key available`() {
         val bundle = mock<Bundle>()
 
         whenever(bundle.getString(EventData.INPUT_KEY_CODE.value)) doReturn null
-        whenever(bundle.getString(EventData.INPUT_KEY_ACTION.value)) doReturn null
 
-        val (key, action) = bundle.extractInputKey()
+        val inputKey = bundle.extractInputKey()
 
-        assertEquals(Key.UNDEFINED, key)
-        assertEquals(Action.UNDEFINED, action)
+        assertNull(inputKey?.key)
     }
 
     @Test
-    fun `should return undefined key and action when the key and action are not mapped`() {
+    fun `should return null action when the action are not mapped`() {
         val bundle = mock<Bundle>()
 
-        whenever(bundle.getString(EventData.INPUT_KEY_CODE.value)) doReturn "unknown"
-        whenever(bundle.getString(EventData.INPUT_KEY_ACTION.value)) doReturn "unknown"
+        whenever(bundle.getString(EventData.INPUT_KEY_ACTION.value)) doReturn null
 
-        val (key, action) = bundle.extractInputKey()
+        val inputKey = bundle.extractInputKey()
 
-        assertEquals(Key.UNDEFINED, key)
-        assertEquals(Action.UNDEFINED, action)
+        assertNull(inputKey?.action)
     }
 }

--- a/clappr/src/test/kotlin/io/clappr/player/plugin/control/MediaControlTest.kt
+++ b/clappr/src/test/kotlin/io/clappr/player/plugin/control/MediaControlTest.kt
@@ -523,7 +523,7 @@ class MediaControlTest {
     }
     
     @Test
-    fun `should hide media control when show is called with a duration in greater than zero`(){
+    fun `should hide media control when show is called with a duration greater than zero`(){
         fakePlayback.fakeState = Playback.State.PLAYING
 
         mediaControl.show(1)

--- a/clappr/src/test/kotlin/io/clappr/player/plugin/control/MediaControlTest.kt
+++ b/clappr/src/test/kotlin/io/clappr/player/plugin/control/MediaControlTest.kt
@@ -41,8 +41,7 @@ class MediaControlTest {
     private lateinit var core: Core
     private lateinit var container: Container
     private lateinit var fakePlayback: FakePlayback
-    lateinit var scheduler: Scheduler
-
+    private lateinit var scheduler: Scheduler
 
     @Before
     fun setUp() {

--- a/clappr/src/test/kotlin/io/clappr/player/plugin/control/MediaControlTest.kt
+++ b/clappr/src/test/kotlin/io/clappr/player/plugin/control/MediaControlTest.kt
@@ -22,10 +22,12 @@ import org.junit.After
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.robolectric.Robolectric
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 import org.robolectric.shadows.ShadowSystemClock
 import org.robolectric.shadows.ShadowView
+import org.robolectric.util.Scheduler
 import java.util.*
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -39,10 +41,14 @@ class MediaControlTest {
     private lateinit var core: Core
     private lateinit var container: Container
     private lateinit var fakePlayback: FakePlayback
+    lateinit var scheduler: Scheduler
+
 
     @Before
     fun setUp() {
         BaseObject.applicationContext = ApplicationProvider.getApplicationContext()
+        scheduler = Robolectric.getForegroundThreadScheduler()
+
         container = Container(Options())
 
         core = Core(Options())
@@ -514,6 +520,31 @@ class MediaControlTest {
         })
 
         assertEquals(UIPlugin.Visibility.HIDDEN, mediaControl.visibility)
+    }
+
+
+    @Test
+    fun `should hide media control when duration in greater than zero`(){
+
+        fakePlayback.fakeState = Playback.State.PLAYING
+
+        mediaControl.show(1)
+
+        scheduler.advanceToNextPostedRunnable()
+
+        assertEquals(UIPlugin.Visibility.HIDDEN, mediaControl.visibility)
+    }
+
+    @Test
+    fun `should not hide media control when duration in less or equal zero`(){
+
+        fakePlayback.fakeState = Playback.State.PLAYING
+
+        mediaControl.show(0)
+
+        scheduler.advanceToNextPostedRunnable()
+
+        assertEquals(UIPlugin.Visibility.VISIBLE, mediaControl.visibility)
     }
 
     private fun getCenterPanel() = mediaControl.view.findViewById<LinearLayout>(R.id.center_panel)

--- a/clappr/src/test/kotlin/io/clappr/player/plugin/control/MediaControlTest.kt
+++ b/clappr/src/test/kotlin/io/clappr/player/plugin/control/MediaControlTest.kt
@@ -524,7 +524,6 @@ class MediaControlTest {
     
     @Test
     fun `should hide media control when show is called with a duration in greater than zero`(){
-
         fakePlayback.fakeState = Playback.State.PLAYING
 
         mediaControl.show(1)
@@ -536,7 +535,6 @@ class MediaControlTest {
 
     @Test
     fun `should not hide media control when show is called with a duration less or equal to zero`(){
-
         fakePlayback.fakeState = Playback.State.PLAYING
 
         mediaControl.show(0)

--- a/clappr/src/test/kotlin/io/clappr/player/plugin/control/MediaControlTest.kt
+++ b/clappr/src/test/kotlin/io/clappr/player/plugin/control/MediaControlTest.kt
@@ -524,7 +524,7 @@ class MediaControlTest {
 
 
     @Test
-    fun `should hide media control when duration in greater than zero`(){
+    fun `should hide media control when show is called with a duration in greater than zero`(){
 
         fakePlayback.fakeState = Playback.State.PLAYING
 
@@ -536,7 +536,7 @@ class MediaControlTest {
     }
 
     @Test
-    fun `should not hide media control when duration in less or equal zero`(){
+    fun `should not hide media control when show is called with a duration less or equal to zero`(){
 
         fakePlayback.fakeState = Playback.State.PLAYING
 

--- a/clappr/src/test/kotlin/io/clappr/player/plugin/control/MediaControlTest.kt
+++ b/clappr/src/test/kotlin/io/clappr/player/plugin/control/MediaControlTest.kt
@@ -521,8 +521,7 @@ class MediaControlTest {
 
         assertEquals(UIPlugin.Visibility.HIDDEN, mediaControl.visibility)
     }
-
-
+    
     @Test
     fun `should hide media control when show is called with a duration in greater than zero`(){
 


### PR DESCRIPTION
### Goal
Make Media Control visible when playback is idle. Now, when stop method is called, the media control will show up and if the video starts to play again, it will be hidden with fade out time.

Also, a Bundle extension function was created to get remote control key and action.

### How to test

Run player unit tests: ./gradlew clean test