### PR TITLE
Fixes duration calculation for Live videos with DVR

### DIFF
--- a/clappr/src/main/kotlin/io/clappr/player/playback/ExoPlayerPlayback.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/playback/ExoPlayerPlayback.kt
@@ -66,7 +66,7 @@ open class ExoPlayerPlayback(
         options[MIN_DVR_SIZE.value] as? Int ?: DEFAULT_MIN_DVR_SIZE
     }
 
-    var player: SimpleExoPlayer? = null
+    protected var player: SimpleExoPlayer? = null
     protected val bandwidthMeter = DefaultBandwidthMeter()
 
     private val mainHandler = Handler()

--- a/clappr/src/main/kotlin/io/clappr/player/playback/ExoPlayerPlayback.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/playback/ExoPlayerPlayback.kt
@@ -66,7 +66,7 @@ open class ExoPlayerPlayback(
         options[MIN_DVR_SIZE.value] as? Int ?: DEFAULT_MIN_DVR_SIZE
     }
 
-    protected var player: SimpleExoPlayer? = null
+    var player: SimpleExoPlayer? = null
     protected val bandwidthMeter = DefaultBandwidthMeter()
 
     private val mainHandler = Handler()
@@ -120,8 +120,8 @@ open class ExoPlayerPlayback(
             return UNKNOWN
         }
 
-    private val syncBufferInSeconds =
-        if (mediaType == LIVE) DEFAULT_SYNC_BUFFER_IN_SECONDS + MIN_DVR_LIVE_DRIFT else 0
+    private val syncBufferInSeconds
+        get() = if (mediaType == LIVE) DEFAULT_SYNC_BUFFER_IN_SECONDS + MIN_DVR_LIVE_DRIFT else 0
 
     override val duration: Double
         get() = player?.duration?.let { (it.toDouble() / ONE_SECOND_IN_MILLIS) - syncBufferInSeconds }


### PR DESCRIPTION
Goal
---
Fixes duration calculation for Live videos with DVR

Context
---
The duration of live videos with DVR was not discounting the syncBufferInSeconds (20s as default) as it should.
