### PR TITLE
Clear hide handler when Media Control is already hidden

### DIFF
--- a/clappr/src/main/kotlin/io/clappr/player/plugin/control/MediaControl.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/plugin/control/MediaControl.kt
@@ -406,6 +406,7 @@ open class MediaControl(core: Core, pluginName: String = name) :
         hideModalPanel()
         hideAnimationEnded = true
 
+        handler.removeCallbacksAndMessages(null)
         core.trigger(InternalEvent.DID_HIDE_MEDIA_CONTROL.value)
     }
 

--- a/clappr/src/test/kotlin/io/clappr/player/plugin/control/MediaControlTest.kt
+++ b/clappr/src/test/kotlin/io/clappr/player/plugin/control/MediaControlTest.kt
@@ -543,6 +543,21 @@ class MediaControlTest {
         assertEquals(UIPlugin.Visibility.VISIBLE, mediaControl.visibility)
     }
 
+    @Test
+    fun `should remove scheduled hide when show is called and hide is executed`(){
+        val expectedHideEventsTriggered = 1
+        fakePlayback.fakeState = Playback.State.PLAYING
+
+        var eventTriggeredCount = 0
+        core.on(InternalEvent.DID_HIDE_MEDIA_CONTROL.value) { eventTriggeredCount += 1 }
+
+        mediaControl.show(1)
+        mediaControl.hide()
+        scheduler.advanceToNextPostedRunnable()
+
+        assertEquals(expectedHideEventsTriggered, eventTriggeredCount)
+    }
+
     private fun getCenterPanel() = mediaControl.view.findViewById<LinearLayout>(R.id.center_panel)
     private fun getBottomPanel() = mediaControl.view.findViewById<LinearLayout>(R.id.bottom_panel)
     private fun getBottomLeftPanel() = mediaControl.view.findViewById<LinearLayout>(R.id.bottom_left_panel)


### PR DESCRIPTION
Goal
---

When we show the Media Control we schedule a hide, however this handler can still run even when the Media Control is already hidden. So is important to clear the handler when Media Control is already hidden.

How to Test
---
Run unit tests: `./gradlew clean test`