### PR TITLE
Add Picture in Picture Support

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -12,7 +12,9 @@
         android:name="io.clappr.player.app.PlayerApp" >
         <activity
             android:name=".PlayerActivity"
-            android:configChanges="orientation|screenSize|keyboardHidden"
+            android:resizeableActivity="true"
+            android:supportsPictureInPicture="true"
+            android:configChanges="orientation|screenSize|smallestScreenSize|screenLayout|keyboardHidden"
             android:label="@string/title_activity_player" >
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/app/src/main/kotlin/io/clappr/player/app/PlayerActivity.kt
+++ b/app/src/main/kotlin/io/clappr/player/app/PlayerActivity.kt
@@ -90,8 +90,8 @@ class PlayerActivity : FragmentActivity() {
     }
 
     override fun onUserLeaveHint() {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
-            enterPictureInPictureMode()
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            player.enterPictureInPictureMode()
         }
     }
 

--- a/app/src/main/kotlin/io/clappr/player/app/PlayerActivity.kt
+++ b/app/src/main/kotlin/io/clappr/player/app/PlayerActivity.kt
@@ -2,6 +2,7 @@ package io.clappr.player.app
 
 import android.content.pm.ActivityInfo
 import android.content.res.Configuration
+import android.os.Build
 import android.os.Bundle
 import android.view.View
 import android.view.ViewGroup
@@ -86,6 +87,12 @@ class PlayerActivity : FragmentActivity() {
 
     private fun changeVideo() {
         loadVideo()
+    }
+
+    override fun onUserLeaveHint() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+            enterPictureInPictureMode()
+        }
     }
 
     private fun enterFullscreen() {

--- a/app/src/main/kotlin/io/clappr/player/app/plugin/NextVideoPlugin.kt
+++ b/app/src/main/kotlin/io/clappr/player/app/plugin/NextVideoPlugin.kt
@@ -1,6 +1,7 @@
 package io.clappr.player.app.plugin
 
 import android.view.LayoutInflater
+import android.view.View
 import android.widget.ImageView
 import android.widget.LinearLayout
 import android.widget.RelativeLayout
@@ -8,6 +9,7 @@ import com.squareup.picasso.Picasso
 import io.clappr.player.app.R
 import io.clappr.player.base.*
 import io.clappr.player.components.Core
+import io.clappr.player.plugin.Plugin
 import io.clappr.player.plugin.PluginEntry
 import io.clappr.player.plugin.core.UICorePlugin
 
@@ -26,6 +28,17 @@ class NextVideoPlugin(core: Core) : UICorePlugin(core, name = name) {
     override val view by lazy {
         LayoutInflater.from(applicationContext).inflate(R.layout.next_video_plugin, null) as RelativeLayout
     }
+
+    override var state: Plugin.State = Plugin.State.ENABLED
+        set(value) {
+            if (value == Plugin.State.ENABLED) {
+                bindPlaybackEvents()
+            } else {
+                stopPlaybackListeners()
+                hide()
+            }
+            field = value
+        }
 
     private val videoListView by lazy { view.findViewById(R.id.video_list) as LinearLayout }
 
@@ -59,6 +72,12 @@ class NextVideoPlugin(core: Core) : UICorePlugin(core, name = name) {
         listenTo(core, InternalEvent.DID_CHANGE_ACTIVE_PLAYBACK.value) {
             hide()
             bindPlaybackEvents()
+        }
+        listenTo(core, Event.DID_ENTER_PIP.value) {
+            state = Plugin.State.DISABLED
+        }
+        listenTo(core, Event.DID_EXIT_PIP.value) {
+            state = Plugin.State.ENABLED
         }
     }
 

--- a/clappr/src/main/kotlin/io/clappr/player/Player.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/Player.kt
@@ -8,6 +8,7 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
+import android.content.pm.PackageManager
 import android.graphics.drawable.Icon
 import android.os.Build
 import android.os.Bundle
@@ -17,7 +18,6 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.annotation.DrawableRes
-import androidx.annotation.RequiresApi
 import androidx.fragment.app.Fragment
 import io.clappr.player.base.*
 import io.clappr.player.components.Core
@@ -210,7 +210,7 @@ open class Player(
 
     private val fastForwardAction by lazy { createRemoteAction(R.drawable.exo_icon_fastforward, "Fast Foward", PIP_ACTION_FAST_FORWARD, PIP_ACTION_FAST_FORWARD) }
 
-    private val pipParametersBuilder by lazy @RequiresApi(Build.VERSION_CODES.O) { PictureInPictureParams.Builder() }
+    private val pipParametersBuilder by lazy @TargetApi(Build.VERSION_CODES.O) { PictureInPictureParams.Builder() }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         playerViewGroup = inflater.inflate(R.layout.player_fragment, container, false) as ViewGroup
@@ -327,8 +327,7 @@ open class Player(
                 listenTo(it, event) { bundle: Bundle? ->
                     trigger(event, bundle)
 
-                    @RequiresApi(Build.VERSION_CODES.O)
-                    if (activity.isInPictureInPictureMode) {
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
                         when (event) {
                             Event.DID_STOP.value -> updatePictureInPictureAction(state)
                             Event.PLAYING.value -> updatePictureInPictureAction(state)
@@ -422,9 +421,12 @@ open class Player(
     }
 
     @TargetApi(Build.VERSION_CODES.O)
-    fun enterPictureInPictureMode() {
-        requireActivity().enterPictureInPictureMode(createPipParameters())
-    }
+    fun enterPictureInPictureMode(): Boolean =
+            if (isPIPSupported())
+                requireActivity().enterPictureInPictureMode(createPipParameters())
+            else false
+
+    private fun isPIPSupported() = requireActivity().packageManager.hasSystemFeature(PackageManager.FEATURE_PICTURE_IN_PICTURE)
 
     @TargetApi(Build.VERSION_CODES.O)
     private fun createPipParameters(): PictureInPictureParams {

--- a/clappr/src/main/kotlin/io/clappr/player/Player.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/Player.kt
@@ -29,6 +29,7 @@ import io.clappr.player.plugin.PlaybackConfig
 import io.clappr.player.plugin.PluginConfig
 import io.clappr.player.plugin.core.externalinput.ExternalInputDevice
 import io.clappr.player.plugin.core.externalinput.ExternalInputPlugin
+import kotlin.math.max
 import kotlin.math.min
 
 /**
@@ -414,7 +415,7 @@ open class Player(
                     pause()
                     updatePIPParameters()
                 }
-                REWIND -> seek(min(0.0, position - SEEK_DEFAULT_JUMP_IN_SECONDS).toInt())
+                REWIND -> seek(max(0.0, position - SEEK_DEFAULT_JUMP_IN_SECONDS).toInt())
                 FAST_FORWARD -> seek(min(duration, position + SEEK_DEFAULT_JUMP_IN_SECONDS).toInt())
             }
         }

--- a/clappr/src/main/kotlin/io/clappr/player/Player.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/Player.kt
@@ -1,8 +1,10 @@
 package io.clappr.player
 
 import android.content.Context
+import android.content.res.Configuration
 import android.os.Bundle
 import android.view.KeyEvent
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -346,5 +348,13 @@ open class Player(
 
     fun holdKeyEvent(event: KeyEvent) {
         externalInputDevice?.holdKeyEvent(event)
+    }
+    
+    override fun onPictureInPictureModeChanged(isInPictureInPictureMode: Boolean, newConfig: Configuration?) {
+        Log.d("@@@", "Is in PiP mode: $isInPictureInPictureMode")
+
+        if (isInPictureInPictureMode) { play() }
+
+        super.onPictureInPictureModeChanged(isInPictureInPictureMode, newConfig)
     }
 }

--- a/clappr/src/main/kotlin/io/clappr/player/Player.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/Player.kt
@@ -317,10 +317,15 @@ open class Player(
         core?.activePlayback?.let {
             playbackEventsToListen.mapTo(playbackEventsIds) { event ->
                 listenTo(it, event) { bundle: Bundle? ->
-                    trigger(
-                        event,
-                        bundle
-                    )
+                    trigger(event, bundle)
+
+                    @RequiresApi(Build.VERSION_CODES.O)
+                    if (activity.isInPictureInPictureMode) {
+                        when (event) {
+                            Event.DID_STOP.value -> updatePictureInPictureAction(state)
+                            Event.PLAYING.value -> updatePictureInPictureAction(state)
+                        }
+                    }
                 }
             }
         }
@@ -395,8 +400,7 @@ open class Player(
                         }
                         3 -> seek(Math.min(duration, position - 10).toInt()) //TODO: check for miminal duration
                         4 -> seek(Math.min(duration, position + 10).toInt())
-                        else -> {
-                        }
+                        else -> Unit
                     }
                 }
             }
@@ -404,6 +408,7 @@ open class Player(
         } else {
             core?.trigger(Event.DID_EXIT_PIP.value)
             receiver?.let { requireActivity().unregisterReceiver(it) }
+            receiver = null
         }
 
         super.onPictureInPictureModeChanged(isInPictureInPictureMode)

--- a/clappr/src/main/kotlin/io/clappr/player/Player.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/Player.kt
@@ -390,8 +390,8 @@ open class Player(
                             pause()
                             updatePIPParameters()
                         }
-                        REWIND -> seek(min(0.0, position - 10).toInt())
-                        FAST_FORWARD -> seek(min(duration, position + 10).toInt())
+                        REWIND -> seek(min(0.0, position - SEEK_DEFAULT_JUMP_IN_SECONDS).toInt())
+                        FAST_FORWARD -> seek(min(duration, position + SEEK_DEFAULT_JUMP_IN_SECONDS).toInt())
                     }
                 }
             }
@@ -451,6 +451,9 @@ open class Player(
     }
 
     companion object {
+
+        private const val SEEK_DEFAULT_JUMP_IN_SECONDS = 10
+
         init {
             PluginConfig.register()
             PlaybackConfig.register()

--- a/clappr/src/main/kotlin/io/clappr/player/Player.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/Player.kt
@@ -200,7 +200,7 @@ open class Player(
 
     private val rewindAction by lazy { createRemoteAction(R.drawable.exo_icon_rewind, "Rewind", 3, 3) }
 
-    private val fastFowardAction by lazy { createRemoteAction(R.drawable.exo_icon_fastforward, "Fast Foward", 4, 4) }
+    private val fastForwardAction by lazy { createRemoteAction(R.drawable.exo_icon_fastforward, "Fast Foward", 4, 4) }
 
     private val pipParametersBuilder by lazy @RequiresApi(Build.VERSION_CODES.O) { PictureInPictureParams.Builder() }
 
@@ -416,7 +416,7 @@ open class Player(
 
     @TargetApi(Build.VERSION_CODES.O)
     private fun createPipParameters(): PictureInPictureParams {
-        return pipParametersBuilder.setActions(listOf(rewindAction, pauseAction, fastFowardAction)).build()
+        return pipParametersBuilder.setActions(listOf(rewindAction, pauseAction, fastForwardAction)).build()
     }
 
     @TargetApi(Build.VERSION_CODES.O)
@@ -433,7 +433,7 @@ open class Player(
             State.PLAYING -> pauseAction
             else -> playAction
         }
-        pipParametersBuilder.setActions(listOf(rewindAction, middleAction, fastFowardAction))
+        pipParametersBuilder.setActions(listOf(rewindAction, middleAction, fastForwardAction))
         requireActivity().setPictureInPictureParams(pipParametersBuilder.build())
     }
 }

--- a/clappr/src/main/kotlin/io/clappr/player/Player.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/Player.kt
@@ -11,7 +11,6 @@ import android.content.pm.PackageManager
 import android.graphics.drawable.Icon
 import android.os.Build
 import android.os.Bundle
-import android.util.Log
 import android.view.KeyEvent
 import android.view.LayoutInflater
 import android.view.View
@@ -19,6 +18,7 @@ import android.view.ViewGroup
 import androidx.annotation.DrawableRes
 import androidx.annotation.RequiresApi
 import androidx.fragment.app.Fragment
+import io.clappr.player.Player.PIPAction.*
 import io.clappr.player.Player.PIPAction.Companion.PIP_INTENT_ACTION
 import io.clappr.player.Player.PIPAction.Companion.PIP_INTENT_EXTRA
 import io.clappr.player.base.*
@@ -128,20 +128,9 @@ open class Player(
     private val playbackEventsIds = mutableSetOf<String>()
     private val containerEventsIds = mutableSetOf<String>()
     private val coreEventsIds = mutableSetOf<String>()
-    private val pipParametersBuilder by lazy @RequiresApi(Build.VERSION_CODES.O) { PictureInPictureParams.Builder() }
 
-    private val playAction by lazy @RequiresApi(Build.VERSION_CODES.O) {
-        createRemoteAction(R.drawable.exo_controls_play, "Play", PIPAction.PLAY)
-    }
-    private val pauseAction by lazy @RequiresApi(Build.VERSION_CODES.O) {
-        createRemoteAction(R.drawable.exo_icon_pause, "Pause", PIPAction.PAUSE)
-    }
-    private val rewindAction by lazy @RequiresApi(Build.VERSION_CODES.O) {
-        createRemoteAction(R.drawable.exo_icon_rewind, "Rewind", PIPAction.REWIND)
-    }
-    private val fastForwardAction by lazy @RequiresApi(Build.VERSION_CODES.O) {
-        createRemoteAction(R.drawable.exo_icon_fastforward, "Fast Foward", PIPAction.FAST_FORWARD)
-    }
+    @RequiresApi(Build.VERSION_CODES.O)
+    private val remoteActions: MutableMap<PIPAction, RemoteAction> = mutableMapOf()
 
     init {
         Event.values().forEach { playbackEventsToListen.add(it.value) }
@@ -330,8 +319,6 @@ open class Player(
     override fun onPictureInPictureModeChanged(
         isInPictureInPictureMode: Boolean
     ) {
-        Log.d("@@@", "Is in PiP mode: $isInPictureInPictureMode")
-
         if (isInPictureInPictureMode) {
             core?.trigger(Event.DID_ENTER_PIP.value)
 
@@ -341,16 +328,16 @@ open class Player(
 
                     val action = PIPAction.valueOf(intent.getStringExtra(PIP_INTENT_EXTRA))
                     when (action) {
-                        PIPAction.PLAY -> {
+                        PLAY -> {
                             play()
                             updateRemoteActions(state)
                         }
-                        PIPAction.PAUSE -> {
+                        PAUSE -> {
                             pause()
                             updateRemoteActions(state)
                         }
-                        PIPAction.REWIND -> seek(min(0.0, position - 10).toInt())
-                        PIPAction.FAST_FORWARD -> seek(min(duration, position + 10).toInt())
+                        REWIND -> seek(min(0.0, position - 10).toInt())
+                        FAST_FORWARD -> seek(min(duration, position + 10).toInt())
                     }
                 }
             }
@@ -375,15 +362,30 @@ open class Player(
 
     @RequiresApi(Build.VERSION_CODES.O)
     private fun createPIPDefaultParameters(): PictureInPictureParams {
-        return pipParametersBuilder.setActions(listOf(rewindAction, pauseAction, fastForwardAction))
-            .build()
+        createRemoteActions()
+        return PictureInPictureParams.Builder().setActions(
+            listOf(
+                remoteActions[REWIND],
+                remoteActions[PAUSE],
+                remoteActions[FAST_FORWARD]
+            )
+        ).build()
     }
 
     @RequiresApi(Build.VERSION_CODES.O)
-    private fun createRemoteAction(
-        @DrawableRes iconId: Int, title: String,
-        action: PIPAction
-    ): RemoteAction {
+    private fun createRemoteActions() {
+        listOf(
+            PLAY to R.drawable.exo_controls_play,
+            PAUSE to R.drawable.exo_icon_pause,
+            REWIND to R.drawable.exo_icon_rewind,
+            FAST_FORWARD to R.drawable.exo_icon_fastforward
+        ).map { (action, icon) ->
+            remoteActions.put(action, createRemoteAction(icon, action))
+        }
+    }
+
+    @RequiresApi(Build.VERSION_CODES.O)
+    private fun createRemoteAction(@DrawableRes iconId: Int, action: PIPAction): RemoteAction {
         val intent = Intent(PIP_INTENT_ACTION).putExtra(PIP_INTENT_EXTRA, action.name)
         val pendingIntent = PendingIntent.getBroadcast(
             activity,
@@ -392,17 +394,27 @@ open class Player(
             PendingIntent.FLAG_UPDATE_CURRENT
         )
 
-        return RemoteAction(Icon.createWithResource(context, iconId), title, title, pendingIntent)
+        return RemoteAction(
+            Icon.createWithResource(context, iconId),
+            action.name,
+            action.name,
+            pendingIntent
+        )
     }
 
     @RequiresApi(Build.VERSION_CODES.O)
     private fun updateRemoteActions(state: State) {
-        val middleAction = when (state) {
-            State.PLAYING -> pauseAction
-            else -> playAction
-        }
-        pipParametersBuilder.setActions(listOf(rewindAction, middleAction, fastForwardAction))
-        requireActivity().setPictureInPictureParams(pipParametersBuilder.build())
+        val builder = PictureInPictureParams.Builder().setActions(
+            listOf(
+                remoteActions[REWIND],
+                when (state) {
+                    State.PLAYING -> remoteActions[PAUSE]
+                    else -> remoteActions[PLAY]
+                },
+                remoteActions[FAST_FORWARD]
+            )
+        )
+        requireActivity().setPictureInPictureParams(builder.build())
     }
 
     private enum class PIPAction {

--- a/clappr/src/main/kotlin/io/clappr/player/Player.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/Player.kt
@@ -315,6 +315,13 @@ open class Player(
         externalInputDevice?.holdKeyEvent(event)
     }
 
+    /**
+     * Prepares Player to enter picture-in-picture mode and calls the corresponding method
+     * on the Activity.
+     *
+     * @return true if the system successfully entered picture-in-picture mode or was already in
+     * picture-in-picture mode. If the device does not support picture-in-picture, return false.
+     */
     @RequiresApi(Build.VERSION_CODES.O)
     fun enterPictureInPictureMode(): Boolean =
         if (isPIPSupported())

--- a/clappr/src/main/kotlin/io/clappr/player/Player.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/Player.kt
@@ -396,7 +396,6 @@ open class Player(
 
         if (isInPictureInPictureMode) {
             core?.trigger(Event.DID_ENTER_PIP.value)
-            play()
 
             receiver = object : BroadcastReceiver() {
                 override fun onReceive(context: Context, intent: Intent?) {

--- a/clappr/src/main/kotlin/io/clappr/player/Player.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/Player.kt
@@ -61,33 +61,23 @@ open class Player(
                 it.on(InternalEvent.WILL_CHANGE_ACTIVE_CONTAINER.value) { unbindContainerEvents() }
                 it.on(InternalEvent.DID_CHANGE_ACTIVE_CONTAINER.value) { bindContainerEvents() }
                 it.on(Event.REQUEST_FULLSCREEN.value) { bundle: Bundle? ->
-                    trigger(
-                        Event.REQUEST_FULLSCREEN.value,
-                        bundle
-                    )
+                    trigger(Event.REQUEST_FULLSCREEN.value, bundle)
                 }
-                it.on(Event.EXIT_FULLSCREEN.value) { bundle: Bundle? -> trigger(Event.EXIT_FULLSCREEN.value, bundle) }
+                it.on(Event.EXIT_FULLSCREEN.value) { bundle: Bundle? ->
+                    trigger(Event.EXIT_FULLSCREEN.value, bundle)
+                }
                 it.on(Event.MEDIA_OPTIONS_SELECTED.value) { bundle: Bundle? ->
-                    trigger(
-                        Event.MEDIA_OPTIONS_SELECTED.value,
-                        bundle
-                    )
+                    trigger(Event.MEDIA_OPTIONS_SELECTED.value, bundle)
                 }
-                it.on(Event.DID_SELECT_AUDIO.value) { bundle: Bundle? -> trigger(Event.DID_SELECT_AUDIO.value, bundle) }
+                it.on(Event.DID_SELECT_AUDIO.value) { bundle: Bundle? ->
+                    trigger(Event.DID_SELECT_AUDIO.value, bundle)
+                }
                 it.on(Event.DID_SELECT_SUBTITLE.value) { bundle: Bundle? ->
-                    trigger(
-                        Event.DID_SELECT_SUBTITLE.value,
-                        bundle
-                    )
+                    trigger(Event.DID_SELECT_SUBTITLE.value, bundle)
                 }
 
-                if (it.activeContainer != null) {
-                    bindContainerEvents()
-                }
-
-                if (it.activePlayback != null) {
-                    bindPlaybackEvents()
-                }
+                if (it.activeContainer != null) bindContainerEvents()
+                if (it.activePlayback != null) bindPlaybackEvents()
 
                 playerViewGroup?.addView(it.render().view)
             }
@@ -164,7 +154,11 @@ open class Player(
         )
     }
 
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
         playerViewGroup = inflater.inflate(R.layout.player_fragment, container, false) as ViewGroup
         core?.let { playerViewGroup?.addView(it.render().view) }
         return (playerViewGroup as View)
@@ -172,7 +166,7 @@ open class Player(
 
     override fun onPause() {
         super.onPause()
-        activity?.takeUnless { it.isRunningInAndroidTvDevice()}?.let {
+        activity?.takeUnless { it.isRunningInAndroidTvDevice() }?.let {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && it.isInPictureInPictureMode) return
 
             val playerIsNotPaused = core?.activePlayback?.state != Playback.State.PAUSED
@@ -300,10 +294,7 @@ open class Player(
     private fun bindContainerEvents() {
         core?.activeContainer?.let {
             containerEventsToListen.mapTo(containerEventsIds) { event ->
-                listenTo(
-                    it,
-                    event
-                ) { bundle: Bundle? -> trigger(event, bundle) }
+                listenTo(it, event) { bundle: Bundle? -> trigger(event, bundle) }
             }
         }
     }
@@ -316,12 +307,7 @@ open class Player(
     private fun bindCoreEvents() {
         core?.let {
             coreEventsToListen.mapTo(coreEventsIds) { event ->
-                listenTo(it, event) { bundle: Bundle? ->
-                    trigger(
-                        event,
-                        bundle
-                    )
-                }
+                listenTo(it, event) { bundle: Bundle? -> trigger(event, bundle) }
             }
         }
     }
@@ -332,7 +318,8 @@ open class Player(
     }
 
     private fun updateCoreFullScreenStatus() {
-        core?.fullscreenState = if (this.fullscreen) Core.FullscreenState.FULLSCREEN else Core.FullscreenState.EMBEDDED
+        core?.fullscreenState =
+            if (this.fullscreen) Core.FullscreenState.FULLSCREEN else Core.FullscreenState.EMBEDDED
     }
 
     fun holdKeyEvent(event: KeyEvent) {
@@ -340,7 +327,9 @@ open class Player(
     }
 
     @RequiresApi(Build.VERSION_CODES.O)
-    override fun onPictureInPictureModeChanged(isInPictureInPictureMode: Boolean) {
+    override fun onPictureInPictureModeChanged(
+        isInPictureInPictureMode: Boolean
+    ) {
         Log.d("@@@", "Is in PiP mode: $isInPictureInPictureMode")
 
         if (isInPictureInPictureMode) {
@@ -377,21 +366,31 @@ open class Player(
 
     @RequiresApi(Build.VERSION_CODES.O)
     fun enterPictureInPictureMode(): Boolean =
-            if (isPIPSupported())
-                requireActivity().enterPictureInPictureMode(createPipParameters())
-            else false
+        if (isPIPSupported())
+            requireActivity().enterPictureInPictureMode(createPipParameters())
+        else false
 
-    private fun isPIPSupported() = requireActivity().packageManager.hasSystemFeature(PackageManager.FEATURE_PICTURE_IN_PICTURE)
+    private fun isPIPSupported() =
+        requireActivity().packageManager.hasSystemFeature(PackageManager.FEATURE_PICTURE_IN_PICTURE)
 
     @RequiresApi(Build.VERSION_CODES.O)
     private fun createPipParameters(): PictureInPictureParams {
-        return pipParametersBuilder.setActions(listOf(rewindAction, pauseAction, fastForwardAction)).build()
+        return pipParametersBuilder.setActions(listOf(rewindAction, pauseAction, fastForwardAction))
+            .build()
     }
 
     @RequiresApi(Build.VERSION_CODES.O)
-    private fun createRemoteAction(@DrawableRes iconId: Int, title: String, action: PIPAction): RemoteAction {
+    private fun createRemoteAction(
+        @DrawableRes iconId: Int, title: String,
+        action: PIPAction
+    ): RemoteAction {
         val intent = Intent(PIP_INTENT_ACTION).putExtra(PIP_INTENT_EXTRA, action.name)
-        val pendingIntent = PendingIntent.getBroadcast(activity, action.ordinal, intent, PendingIntent.FLAG_UPDATE_CURRENT)
+        val pendingIntent = PendingIntent.getBroadcast(
+            activity,
+            action.ordinal,
+            intent,
+            PendingIntent.FLAG_UPDATE_CURRENT
+        )
 
         return RemoteAction(Icon.createWithResource(context, iconId), title, title, pendingIntent)
     }

--- a/clappr/src/main/kotlin/io/clappr/player/Player.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/Player.kt
@@ -226,7 +226,9 @@ open class Player(
 
     override fun onPause() {
         super.onPause()
-        activity?.takeUnless { it.isRunningInAndroidTvDevice() }?.let {
+        activity?.takeUnless { it.isRunningInAndroidTvDevice()}?.let {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && it.isInPictureInPictureMode) return
+
             val playerIsNotPaused = core?.activePlayback?.state != Playback.State.PAUSED
             if (playerIsNotPaused && !pause())
                 stop()

--- a/clappr/src/main/kotlin/io/clappr/player/Player.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/Player.kt
@@ -67,6 +67,8 @@ open class Player(
         )
     }
 
+    private var receiver: BroadcastReceiver? = null
+
     /**
      * Player state
      */
@@ -364,7 +366,7 @@ open class Player(
         if (isInPictureInPictureMode) {
             play()
 
-            val receiver = object : BroadcastReceiver() {
+            receiver = object : BroadcastReceiver() {
                 override fun onReceive(context: Context, intent: Intent?) {
                     if (intent == null || "media_control" != intent.action) return
 
@@ -384,6 +386,8 @@ open class Player(
             }
 
             requireActivity().registerReceiver(receiver, IntentFilter("media_control"))
+        } else {
+            receiver?.let { requireActivity().unregisterReceiver(it) }
         }
 
         super.onPictureInPictureModeChanged(isInPictureInPictureMode)

--- a/clappr/src/main/kotlin/io/clappr/player/Player.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/Player.kt
@@ -277,8 +277,8 @@ open class Player(
 
                     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
                         when (event) {
-                            Event.DID_STOP.value -> updatePictureInPictureAction(state)
-                            Event.PLAYING.value -> updatePictureInPictureAction(state)
+                            Event.DID_STOP.value -> updateRemoteActions(state)
+                            Event.PLAYING.value -> updateRemoteActions(state)
                         }
                     }
                 }
@@ -343,11 +343,11 @@ open class Player(
                     when (action) {
                         PIPAction.PLAY -> {
                             play()
-                            updatePictureInPictureAction(state)
+                            updateRemoteActions(state)
                         }
                         PIPAction.PAUSE -> {
                             pause()
-                            updatePictureInPictureAction(state)
+                            updateRemoteActions(state)
                         }
                         PIPAction.REWIND -> seek(min(0.0, position - 10).toInt())
                         PIPAction.FAST_FORWARD -> seek(min(duration, position + 10).toInt())
@@ -367,14 +367,14 @@ open class Player(
     @RequiresApi(Build.VERSION_CODES.O)
     fun enterPictureInPictureMode(): Boolean =
         if (isPIPSupported())
-            requireActivity().enterPictureInPictureMode(createPipParameters())
+            requireActivity().enterPictureInPictureMode(createPIPDefaultParameters())
         else false
 
     private fun isPIPSupported() =
         requireActivity().packageManager.hasSystemFeature(PackageManager.FEATURE_PICTURE_IN_PICTURE)
 
     @RequiresApi(Build.VERSION_CODES.O)
-    private fun createPipParameters(): PictureInPictureParams {
+    private fun createPIPDefaultParameters(): PictureInPictureParams {
         return pipParametersBuilder.setActions(listOf(rewindAction, pauseAction, fastForwardAction))
             .build()
     }
@@ -396,7 +396,7 @@ open class Player(
     }
 
     @RequiresApi(Build.VERSION_CODES.O)
-    private fun updatePictureInPictureAction(state: State) {
+    private fun updateRemoteActions(state: State) {
         val middleAction = when (state) {
             State.PLAYING -> pauseAction
             else -> playAction

--- a/clappr/src/main/kotlin/io/clappr/player/Player.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/Player.kt
@@ -1,6 +1,5 @@
 package io.clappr.player
 
-import android.annotation.TargetApi
 import android.app.PendingIntent
 import android.app.PictureInPictureParams
 import android.app.RemoteAction
@@ -18,6 +17,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.annotation.DrawableRes
+import androidx.annotation.RequiresApi
 import androidx.fragment.app.Fragment
 import io.clappr.player.Player.PIPAction.Companion.PIP_INTENT_ACTION
 import io.clappr.player.Player.PIPAction.Companion.PIP_INTENT_EXTRA
@@ -211,12 +211,20 @@ open class Player(
 
     private var playerViewGroup: ViewGroup? = null
 
-    private val playAction by lazy { createRemoteAction(R.drawable.exo_controls_play, "Play", PIPAction.PLAY) }
-    private val pauseAction by lazy { createRemoteAction(R.drawable.exo_icon_pause, "Pause", PIPAction.PAUSE) }
-    private val rewindAction by lazy { createRemoteAction(R.drawable.exo_icon_rewind, "Rewind", PIPAction.REWIND) }
-    private val fastForwardAction by lazy { createRemoteAction(R.drawable.exo_icon_fastforward, "Fast Foward", PIPAction.FAST_FORWARD) }
+    private val playAction by lazy @RequiresApi(Build.VERSION_CODES.O) {
+        createRemoteAction(R.drawable.exo_controls_play, "Play", PIPAction.PLAY)
+    }
+    private val pauseAction by lazy @RequiresApi(Build.VERSION_CODES.O) {
+        createRemoteAction(R.drawable.exo_icon_pause, "Pause", PIPAction.PAUSE)
+    }
+    private val rewindAction by lazy @RequiresApi(Build.VERSION_CODES.O) {
+        createRemoteAction(R.drawable.exo_icon_rewind, "Rewind", PIPAction.REWIND)
+    }
+    private val fastForwardAction by lazy @RequiresApi(Build.VERSION_CODES.O) {
+        createRemoteAction(R.drawable.exo_icon_fastforward, "Fast Foward", PIPAction.FAST_FORWARD)
+    }
 
-    private val pipParametersBuilder by lazy @TargetApi(Build.VERSION_CODES.O) { PictureInPictureParams.Builder() }
+    private val pipParametersBuilder by lazy @RequiresApi(Build.VERSION_CODES.O) { PictureInPictureParams.Builder() }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         playerViewGroup = inflater.inflate(R.layout.player_fragment, container, false) as ViewGroup
@@ -392,7 +400,8 @@ open class Player(
     fun holdKeyEvent(event: KeyEvent) {
         externalInputDevice?.holdKeyEvent(event)
     }
-    
+
+    @RequiresApi(Build.VERSION_CODES.O)
     override fun onPictureInPictureModeChanged(isInPictureInPictureMode: Boolean) {
         Log.d("@@@", "Is in PiP mode: $isInPictureInPictureMode")
 
@@ -402,7 +411,6 @@ open class Player(
             receiver = object : BroadcastReceiver() {
                 override fun onReceive(context: Context, intent: Intent?) {
                     if (intent == null || PIP_INTENT_ACTION != intent.action) return
-
 
                     val action = PIPAction.valueOf(intent.getStringExtra(PIP_INTENT_EXTRA))
                     when (action) {
@@ -429,7 +437,7 @@ open class Player(
         super.onPictureInPictureModeChanged(isInPictureInPictureMode)
     }
 
-    @TargetApi(Build.VERSION_CODES.O)
+    @RequiresApi(Build.VERSION_CODES.O)
     fun enterPictureInPictureMode(): Boolean =
             if (isPIPSupported())
                 requireActivity().enterPictureInPictureMode(createPipParameters())
@@ -437,12 +445,12 @@ open class Player(
 
     private fun isPIPSupported() = requireActivity().packageManager.hasSystemFeature(PackageManager.FEATURE_PICTURE_IN_PICTURE)
 
-    @TargetApi(Build.VERSION_CODES.O)
+    @RequiresApi(Build.VERSION_CODES.O)
     private fun createPipParameters(): PictureInPictureParams {
         return pipParametersBuilder.setActions(listOf(rewindAction, pauseAction, fastForwardAction)).build()
     }
 
-    @TargetApi(Build.VERSION_CODES.O)
+    @RequiresApi(Build.VERSION_CODES.O)
     private fun createRemoteAction(@DrawableRes iconId: Int, title: String, action: PIPAction): RemoteAction {
         val intent = Intent(PIP_INTENT_ACTION).putExtra(PIP_INTENT_EXTRA, action.name)
         val pendingIntent = PendingIntent.getBroadcast(activity, action.ordinal, intent, PendingIntent.FLAG_UPDATE_CURRENT)
@@ -450,7 +458,7 @@ open class Player(
         return RemoteAction(Icon.createWithResource(context, iconId), title, title, pendingIntent)
     }
 
-    @TargetApi(Build.VERSION_CODES.O)
+    @RequiresApi(Build.VERSION_CODES.O)
     private fun updatePictureInPictureAction(state: State) {
         val middleAction = when (state) {
             State.PLAYING -> pauseAction

--- a/clappr/src/main/kotlin/io/clappr/player/Player.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/Player.kt
@@ -364,6 +364,7 @@ open class Player(
         Log.d("@@@", "Is in PiP mode: $isInPictureInPictureMode")
 
         if (isInPictureInPictureMode) {
+            core?.trigger(Event.DID_ENTER_PIP.value)
             play()
 
             receiver = object : BroadcastReceiver() {
@@ -387,6 +388,7 @@ open class Player(
 
             requireActivity().registerReceiver(receiver, IntentFilter("media_control"))
         } else {
+            core?.trigger(Event.DID_EXIT_PIP.value)
             receiver?.let { requireActivity().unregisterReceiver(it) }
         }
 

--- a/clappr/src/main/kotlin/io/clappr/player/Player.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/Player.kt
@@ -76,6 +76,8 @@ open class Player(
                 it.on(Event.DID_SELECT_SUBTITLE.value) { bundle: Bundle? ->
                     trigger(Event.DID_SELECT_SUBTITLE.value, bundle)
                 }
+                it.on(Event.DID_ENTER_PIP.value) { trigger(Event.DID_ENTER_PIP.value) }
+                it.on(Event.DID_EXIT_PIP.value) { trigger(Event.DID_EXIT_PIP.value) }
 
                 if (it.activeContainer != null) bindContainerEvents()
                 if (it.activePlayback != null) bindPlaybackEvents()

--- a/clappr/src/main/kotlin/io/clappr/player/base/Events.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/base/Events.kt
@@ -168,7 +168,17 @@ enum class Event(val value: String) {
     /**
      * There was a change in screen orientation
      */
-    DID_CHANGE_SCREEN_ORIENTATION("didChangeScreenOrientation")
+    DID_CHANGE_SCREEN_ORIENTATION("didChangeScreenOrientation"),
+     
+    /**
+     * Did Enter Picture in Picture Mode
+     */
+    DID_ENTER_PIP("didEnterPiP"),
+
+    /**
+     * Did Exit Picture in Picture Mode
+     */
+    DID_EXIT_PIP("didExitPiP")
 }
 
 /**

--- a/clappr/src/main/kotlin/io/clappr/player/plugin/control/MediaControl.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/plugin/control/MediaControl.kt
@@ -151,6 +151,9 @@ open class MediaControl(core: Core, pluginName: String = name) :
         listenTo(core, InternalEvent.CLOSE_MODAL_PANEL.value) { closeModal() }
 
         listenTo(core, Event.DID_RECEIVE_INPUT_KEY.value) { onInputReceived(it) }
+        
+        listenTo(core, Event.DID_ENTER_PIP.value) { state = State.DISABLED }
+        listenTo(core, Event.DID_EXIT_PIP.value) { state = State.ENABLED }
     }
 
     open fun handleDidPauseEvent() {
@@ -202,6 +205,7 @@ open class MediaControl(core: Core, pluginName: String = name) :
                     InternalEvent.DISABLE_MEDIA_CONTROL.value
                 ) { state = State.DISABLED })
             containerListenerIds.add(listenTo(it, InternalEvent.WILL_LOAD_SOURCE.value) {
+                //TODO: Handle state when in PiP mode
                 state = State.ENABLED
                 hide()
             })

--- a/clappr/src/main/kotlin/io/clappr/player/plugin/control/MediaControl.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/plugin/control/MediaControl.kt
@@ -22,6 +22,7 @@ import io.clappr.player.extensions.extractInputKey
 import io.clappr.player.extensions.unlessChromeless
 import io.clappr.player.plugin.Plugin.State
 import io.clappr.player.plugin.PluginEntry
+import io.clappr.player.plugin.UIPlugin
 import io.clappr.player.plugin.UIPlugin.Visibility
 import io.clappr.player.plugin.core.UICorePlugin
 
@@ -102,11 +103,16 @@ open class MediaControl(core: Core, pluginName: String = name) :
 
     override var state: State = State.ENABLED
         set(value) {
-            if (value == State.ENABLED)
+            if (value == State.ENABLED) {
+                setupPlaybackEvents()
                 view.visibility = View.VISIBLE
+                visibility = Visibility.VISIBLE
+            }
             else {
                 hide()
+                stopPlaybackListeners()
                 view.visibility = View.GONE
+                visibility = Visibility.HIDDEN
             }
             field = value
         }

--- a/clappr/src/test/kotlin/io/clappr/player/plugin/control/MediaControlTest.kt
+++ b/clappr/src/test/kotlin/io/clappr/player/plugin/control/MediaControlTest.kt
@@ -773,6 +773,24 @@ class MediaControlTest {
         assertEquals(expectedHideEventsTriggered, eventTriggeredCount)
     }
 
+    @Test
+    fun `should disable media control when did enter pip is triggered`() {
+        mediaControl.state = Plugin.State.ENABLED
+
+        core.trigger(Event.DID_ENTER_PIP.value)
+
+        assertEquals(Plugin.State.DISABLED, mediaControl.state, "Media Control should be disabled")
+    }
+
+    @Test
+    fun `should enable media control when did exit pip is triggered`() {
+        mediaControl.state = Plugin.State.DISABLED
+
+        core.trigger(Event.DID_EXIT_PIP.value)
+
+        assertEquals(Plugin.State.ENABLED, mediaControl.state, "Media Control should be enabled")
+    }
+
     private fun getCenterPanel() = mediaControl.view.findViewById<LinearLayout>(R.id.center_panel)
     private fun getBottomPanel() = mediaControl.view.findViewById<LinearLayout>(R.id.bottom_panel)
     private fun getBottomLeftPanel() = mediaControl.view.findViewById<LinearLayout>(R.id.bottom_left_panel)

--- a/clappr/src/test/kotlin/io/clappr/player/plugin/control/MediaControlTest.kt
+++ b/clappr/src/test/kotlin/io/clappr/player/plugin/control/MediaControlTest.kt
@@ -205,7 +205,6 @@ class MediaControlTest {
         assertEquals(View.VISIBLE, getForegroundControlsPanel().visibility)
     }
 
-
     @Test
     fun `should keep foreground controls panel visibility when close modal event was triggered with hidden modal panel`(){
         fakePlayback.fakeState = Playback.State.PLAYING
@@ -215,7 +214,6 @@ class MediaControlTest {
 
         assertEquals(View.INVISIBLE, getForegroundControlsPanel().visibility)
     }
-
 
     @Test
     fun `should send did open modal panel event when modal panel was opened`() {
@@ -471,7 +469,7 @@ class MediaControlTest {
     }
 
     @Test
-    fun `shoul disable media control on event`() {
+    fun `should disable media control on event`() {
         assertTrue(mediaControl.isEnabled, "Media control should be enabled by default")
 
         triggerDisableMediaControlEvent()
@@ -567,7 +565,7 @@ class MediaControlTest {
     }
 
     @Test
-    fun `should ahow plugins by option with duplicates`() {
+    fun `should show plugins by option with duplicates`() {
         val sequence = "${FakePlugin3.name},${FakePlugin2.name},${FakePlugin.name},${FakePlugin2.name}"
         setupFakeMediaControlPlugins(Panel.BOTTOM, Position.RIGHT, sequence)
 


### PR DESCRIPTION
### 🏁 Goal
Add support for the picture-in-picture feature introduced in Android Oreo (API 26). 

Client applications must follow the configuration steps defined in the official docs to support this functionality in their Activities and after that, all that is needed is calling `player.enterPictureInPictureMode()`.

This PR creates two new events: `DID_ENTER_PIP` and `DID_EXIT_PIP` to notify plugins about this new interaction model. When in PIP mode, `MediaControl` is disabled and only three `RemoteActions` are displayed: seek back, play/pause, seek forward.

### 🖼 Screenshot
![pip mp4](https://user-images.githubusercontent.com/2274568/68502349-f9c6ba80-023e-11ea-9c96-47b4012fd586.gif)

### ✅ How to test
