### PR TITLE
Add Long Press Information to external input event

### DIFF
--- a/clappr/src/main/kotlin/io/clappr/player/base/Events.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/base/Events.kt
@@ -245,6 +245,15 @@ enum class EventData(val value: String) {
     INPUT_KEY_ACTION("inputKeyAction"),
 
     /**
+     * [Event.DID_RECEIVE_INPUT_KEY] data
+     *
+     * Type: Boolean
+     *
+     * Input key is long press. Can be true or false
+     */
+    INPUT_KEY_IS_LONG_PRESS("inputKeyIsLongPress"),
+
+    /**
      * [Event.DID_CHANGE_SCREEN_ORIENTATION] data
      *
      * Type: io.clappr.player.components.Orientation

--- a/clappr/src/main/kotlin/io/clappr/player/extensions/BundleExtensions.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/extensions/BundleExtensions.kt
@@ -5,17 +5,18 @@ import io.clappr.player.base.EventData
 import io.clappr.player.base.keys.Action
 import io.clappr.player.base.keys.Key
 
-data class InputKey(val key: Key, val action: Action)
+data class InputKey(val key: Key, val action: Action, val isLongPress: Boolean)
 
 fun Bundle.extractInputKey(): InputKey? {
     val keyCode = getString(EventData.INPUT_KEY_CODE.value).orEmpty()
     val keyAction = getString(EventData.INPUT_KEY_ACTION.value).orEmpty()
+    val isLongPress = getBoolean(EventData.INPUT_KEY_IS_LONG_PRESS.value, false)
 
     val key = Key.getByValue(keyCode)
     val action = Action.getByValue(keyAction)
 
     return when {
-        key != null && action != null -> InputKey(key, action)
+        key != null && action != null -> InputKey(key, action, isLongPress)
         else -> null
     }
 }

--- a/clappr/src/main/kotlin/io/clappr/player/plugin/core/externalinput/ExternalInputPlugin.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/plugin/core/externalinput/ExternalInputPlugin.kt
@@ -33,6 +33,7 @@ class ExternalInputPlugin(core: Core) : CorePlugin(core, name = name), ExternalI
         core.trigger(Event.DID_RECEIVE_INPUT_KEY.value, Bundle().apply {
             putString(EventData.INPUT_KEY_CODE.value, getKeyCode(event.keyCode))
             putString(EventData.INPUT_KEY_ACTION.value, getActionCode(event.action))
+            putBoolean(EventData.INPUT_KEY_IS_LONG_PRESS.value, event.isLongPress)
         })
     }
 

--- a/clappr/src/test/kotlin/io/clappr/player/extensions/BundleExtensionsTest.kt
+++ b/clappr/src/test/kotlin/io/clappr/player/extensions/BundleExtensionsTest.kt
@@ -22,9 +22,9 @@ class BundleExtensionsTest {
 
         val inputKey = bundle.extractInputKey()
 
-        assertNotNull(inputKey)
-        assertEquals(Key.BACK, inputKey.key)
-        assertEquals(Action.UP, inputKey.action)
+        val expectedInputKey = InputKey(Key.BACK, Action.UP, false)
+
+        assertEquals(expectedInputKey, inputKey)
     }
 
     @Test
@@ -39,8 +39,9 @@ class BundleExtensionsTest {
 
         val inputKey = bundle.extractInputKey()
 
-        assertNotNull(inputKey)
-        assertTrue(inputKey.isLongPress, "Is long press should be true")
+        val expectedInputKey = InputKey(Key.BACK, Action.UP, true)
+
+        assertEquals(expectedInputKey, inputKey)
     }
 
     @Test

--- a/clappr/src/test/kotlin/io/clappr/player/extensions/BundleExtensionsTest.kt
+++ b/clappr/src/test/kotlin/io/clappr/player/extensions/BundleExtensionsTest.kt
@@ -8,25 +8,44 @@ import io.mockk.every
 import io.mockk.mockk
 import org.junit.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
 import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 class BundleExtensionsTest {
     @Test
     fun `should extract key and action from bundle`() {
-        val bundle = mockk<Bundle>()
+        val bundle = mockk<Bundle>(relaxed = true)
 
         every { bundle.getString(EventData.INPUT_KEY_CODE.value) } returns Key.BACK.value
         every { bundle.getString(EventData.INPUT_KEY_ACTION.value) } returns Action.UP.value
 
         val inputKey = bundle.extractInputKey()
 
-        assertEquals(Key.BACK, inputKey?.key)
-        assertEquals(Action.UP, inputKey?.action)
+        assertNotNull(inputKey)
+        assertEquals(Key.BACK, inputKey.key)
+        assertEquals(Action.UP, inputKey.action)
+    }
+
+    @Test
+    fun `should extract is long press flag from bundle`() {
+        val bundle = mockk<Bundle>()
+
+        every { bundle.getString(EventData.INPUT_KEY_CODE.value) } returns Key.BACK.value
+        every { bundle.getString(EventData.INPUT_KEY_ACTION.value) } returns Action.UP.value
+        every {
+            bundle.getBoolean(EventData.INPUT_KEY_IS_LONG_PRESS.value, false)
+        } returns true
+
+        val inputKey = bundle.extractInputKey()
+
+        assertNotNull(inputKey)
+        assertTrue(inputKey.isLongPress, "Is long press should be true")
     }
 
     @Test
     fun `should return null when there is no key available`() {
-        val bundle = mockk<Bundle>()
+        val bundle = mockk<Bundle>(relaxed = true)
 
         every { bundle.getString(EventData.INPUT_KEY_CODE.value) } returns null
         every { bundle.getString(EventData.INPUT_KEY_ACTION.value) } returns Action.UP.value
@@ -38,7 +57,7 @@ class BundleExtensionsTest {
 
     @Test
     fun `should return null when there is no action available`() {
-        val bundle = mockk<Bundle>()
+        val bundle = mockk<Bundle>(relaxed = true)
 
         every { bundle.getString(EventData.INPUT_KEY_CODE.value) } returns Key.BACK.value
         every { bundle.getString(EventData.INPUT_KEY_ACTION.value) } returns null

--- a/clappr/src/test/kotlin/io/clappr/player/plugin/ExternalInputPluginTest.kt
+++ b/clappr/src/test/kotlin/io/clappr/player/plugin/ExternalInputPluginTest.kt
@@ -10,20 +10,24 @@ import io.clappr.player.base.keys.Action
 import io.clappr.player.base.keys.Key
 import io.clappr.player.components.Core
 import io.clappr.player.plugin.core.externalinput.ExternalInputPlugin
+import io.mockk.every
+import io.mockk.mockk
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 @RunWith(RobolectricTestRunner::class)
 class ExternalInputPluginTest {
 
-    lateinit var core: Core
+    private lateinit var core: Core
 
-    lateinit var externalInputPlugin: ExternalInputPlugin
+    private lateinit var externalInputPlugin: ExternalInputPlugin
 
     private val anyKeyCode = -1
+    private val anyKeyAction = -1
 
     @Before
     fun setUp() {
@@ -35,58 +39,76 @@ class ExternalInputPluginTest {
     }
 
     @Test
-    fun `should trigger KEY_PRESSED event for PLAY button`() {
+    fun `should trigger DID_RECEIVE_INPUT_KEY event for PLAY button`() {
         assertPressedKeyCodeEvent(Key.PLAY, KeyEvent.KEYCODE_MEDIA_PLAY)
     }
 
     @Test
-    fun `should trigger KEY_PRESSED event with DOWN action`() {
+    fun `should trigger DID_RECEIVE_INPUT_KEY event with DOWN action`() {
         assertPressedAction(Action.DOWN, KeyEvent.ACTION_DOWN)
     }
 
     @Test
-    fun `should trigger KEY_PRESSED event with UP action`() {
+    fun `should trigger DID_RECEIVE_INPUT_KEY event with UP action`() {
         assertPressedAction(Action.UP, KeyEvent.ACTION_UP)
     }
 
     @Test
-    fun `should trigger KEY_PRESSED event for PAUSE button`() {
+    fun `should trigger DID_RECEIVE_INPUT_KEY event for PAUSE button`() {
         assertPressedKeyCodeEvent(Key.PAUSE, KeyEvent.KEYCODE_MEDIA_PAUSE)
     }
 
     @Test
-    fun `should trigger KEY_PRESSED event for STOP button`() {
+    fun `should trigger DID_RECEIVE_INPUT_KEY event for STOP button`() {
         assertPressedKeyCodeEvent(Key.STOP, KeyEvent.KEYCODE_MEDIA_STOP)
     }
 
     @Test
-    fun `should trigger KEY_PRESSED event for PLAY_PAUSE button`() {
+    fun `should trigger DID_RECEIVE_INPUT_KEY event for PLAY_PAUSE button`() {
         assertPressedKeyCodeEvent(Key.PLAY_PAUSE, KeyEvent.KEYCODE_MEDIA_PLAY_PAUSE)
     }
 
     @Test
-    fun `should trigger KEY_PRESSED event for UP button`() {
+    fun `should trigger DID_RECEIVE_INPUT_KEY event for UP button`() {
         assertPressedKeyCodeEvent(Key.UP, KeyEvent.KEYCODE_DPAD_UP)
     }
 
     @Test
-    fun `should trigger KEY_PRESSED event for DOWN button`() {
+    fun `should trigger DID_RECEIVE_INPUT_KEY event for DOWN button`() {
         assertPressedKeyCodeEvent(Key.DOWN, KeyEvent.KEYCODE_DPAD_DOWN)
     }
 
     @Test
-    fun `should trigger KEY_PRESSED event for LEFT button`() {
+    fun `should trigger DID_RECEIVE_INPUT_KEY event for LEFT button`() {
         assertPressedKeyCodeEvent(Key.LEFT, KeyEvent.KEYCODE_DPAD_LEFT)
     }
 
     @Test
-    fun `should trigger KEY_PRESSED event for RIGHT button`() {
+    fun `should trigger DID_RECEIVE_INPUT_KEY event for RIGHT button`() {
         assertPressedKeyCodeEvent(Key.RIGHT, KeyEvent.KEYCODE_DPAD_RIGHT)
     }
 
     @Test
-    fun `should trigger KEY_PRESSED event for BACK button`() {
+    fun `should trigger DID_RECEIVE_INPUT_KEY event for BACK button`() {
         assertPressedKeyCodeEvent(Key.BACK, KeyEvent.KEYCODE_BACK)
+    }
+
+    @Test
+    fun `should trigger DID_RECEIVE_INPUT_KEY event with key event is long press flag`() {
+        val keyEventMock = mockk<KeyEvent>()
+        var isLongPress = false
+
+        core.on(Event.DID_RECEIVE_INPUT_KEY.value) { bundle ->
+            bundle?.let { isLongPress = it.getBoolean(EventData.INPUT_KEY_IS_LONG_PRESS.value) }
+        }
+
+        every { keyEventMock.keyCode } returns anyKeyCode
+        every { keyEventMock.action } returns anyKeyAction
+        every { keyEventMock.isLongPress } returns true
+
+        externalInputPlugin.holdKeyEvent(keyEventMock)
+
+        assertTrue(isLongPress, "Is long press flag should be true")
     }
 
     private fun assertPressedKeyCodeEvent(expectedKeyCode: Key, keyToHold: Int){
@@ -108,7 +130,7 @@ class ExternalInputPluginTest {
             bundle?.let { actionCode = it.getString(EventData.INPUT_KEY_ACTION.value) }
         }
 
-        externalInputPlugin.holdKeyEvent(KeyEvent(actionKey, anyKeyCode))
+        externalInputPlugin.holdKeyEvent(KeyEvent(actionKey, anyKeyAction))
 
         assertEquals(expectedActionCode.value, actionCode)
     }


### PR DESCRIPTION
Goal
---
Add Long Press information to external input event. The long press is sent as a boolean in the event bundle.

How to Test
---
Run unit tests: `./gradlew clean test`