### PR TITLE
Fix plugin top center position

### DIFF
--- a/clappr/src/main/kotlin/io/clappr/player/plugin/control/MediaControl.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/plugin/control/MediaControl.kt
@@ -74,7 +74,7 @@ open class MediaControl(core: Core, pluginName: String = name) :
 
     private val controlsPanel by lazy { view.findViewById(R.id.controls_panel) as RelativeLayout }
 
-    private val topCenterPanel by lazy { view.findViewById(R.id.top_center) as RelativeLayout }
+    private val topCenterPanel by lazy { view.findViewById(R.id.top_center) as LinearLayout }
     private val topPanel by lazy { view.findViewById(R.id.top_panel) as LinearLayout }
     private val topLeftPanel by lazy { view.findViewById(R.id.top_left_panel) as LinearLayout }
     private val topRightPanel by lazy { view.findViewById(R.id.top_right_panel) as LinearLayout }

--- a/clappr/src/main/kotlin/io/clappr/player/plugin/control/MediaControl.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/plugin/control/MediaControl.kt
@@ -74,7 +74,7 @@ open class MediaControl(core: Core, pluginName: String = name) :
 
     private val controlsPanel by lazy { view.findViewById(R.id.controls_panel) as RelativeLayout }
 
-    private val topCenterPanel by lazy { view.findViewById(R.id.top_center) as LinearLayout }
+    private val topCenterPanel by lazy { view.findViewById(R.id.top_center) as ViewGroup }
     private val topPanel by lazy { view.findViewById(R.id.top_panel) as LinearLayout }
     private val topLeftPanel by lazy { view.findViewById(R.id.top_left_panel) as LinearLayout }
     private val topRightPanel by lazy { view.findViewById(R.id.top_right_panel) as LinearLayout }

--- a/clappr/src/main/res/layout/media_control.xml
+++ b/clappr/src/main/res/layout/media_control.xml
@@ -35,7 +35,6 @@
                 android:orientation="horizontal">
 
                 <RelativeLayout
-                    android:id="@+id/top_center"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content">
 
@@ -53,6 +52,14 @@
                         android:layout_height="wrap_content"
                         android:layout_alignParentEnd="true"
                         android:layout_alignParentRight="true"
+                        android:orientation="horizontal" />
+
+                    <LinearLayout
+                        android:id="@+id/top_center"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_centerHorizontal="true"
+                        android:layout_alignParentTop="true"
                         android:orientation="horizontal" />
                 </RelativeLayout>
 

--- a/clappr/src/test/kotlin/io/clappr/player/plugin/control/MediaControlTest.kt
+++ b/clappr/src/test/kotlin/io/clappr/player/plugin/control/MediaControlTest.kt
@@ -122,12 +122,7 @@ class MediaControlTest {
     @Test
     fun `should add media control plugin in top center panel`() {
         setupFakeMediaControlPlugin(Panel.TOP, Position.CENTER)
-
-        val plugin = core.plugins.asSequence().filterIsInstance(FakePlugin::class.java).first()
-
-        assertEquals(1, getTopCenterPanel().childCount, "Media Control Plugin should be added to Panel.TOP panel and Position.CENTER position in Media Control")
-        assertEquals(FakePlugin.viewId, getTopCenterPanel().getChildAt(0).id, "Media Control Plugin should be added to Media Control")
-        assertEquals(plugin.view, getTopCenterPanel().getChildAt(0))
+        assertMediaControlPanel(getTopCenterPanel(), Panel.TOP, Position.CENTER)
     }
 
     @Test
@@ -610,7 +605,7 @@ class MediaControlTest {
         mediaControl.render()
     }
 
-    private fun assertMediaControlPanel(layoutPanel: LinearLayout, panel: Panel, position: Position) {
+    private fun assertMediaControlPanel(layoutPanel: ViewGroup, panel: Panel, position: Position) {
         val plugin = core.plugins.asSequence().filterIsInstance(FakePlugin::class.java).first()
 
         assertEquals(1, layoutPanel.childCount, "Media Control Plugin should be added to $panel panel and $position position in Media Control")

--- a/clappr/src/test/kotlin/io/clappr/player/plugin/control/MediaControlTest.kt
+++ b/clappr/src/test/kotlin/io/clappr/player/plugin/control/MediaControlTest.kt
@@ -125,9 +125,9 @@ class MediaControlTest {
 
         val plugin = core.plugins.asSequence().filterIsInstance(FakePlugin::class.java).first()
 
-        assertEquals(3, getTopCenterPanel().childCount, "Media Control Plugin should be added to Panel.TOP panel and Position.CENTER position in Media Control")
-        assertEquals(FakePlugin.viewId, getTopCenterPanel().getChildAt(2).id, "Media Control Plugin should be added to Media Control")
-        assertEquals(plugin.view, getTopCenterPanel().getChildAt(2))
+        assertEquals(1, getTopCenterPanel().childCount, "Media Control Plugin should be added to Panel.TOP panel and Position.CENTER position in Media Control")
+        assertEquals(FakePlugin.viewId, getTopCenterPanel().getChildAt(0).id, "Media Control Plugin should be added to Media Control")
+        assertEquals(plugin.view, getTopCenterPanel().getChildAt(0))
     }
 
     @Test
@@ -565,7 +565,7 @@ class MediaControlTest {
     private fun getTopPanel() = mediaControl.view.findViewById<LinearLayout>(R.id.top_panel)
     private fun getTopLeftPanel() = mediaControl.view.findViewById<LinearLayout>(R.id.top_left_panel)
     private fun getTopRightPanel() = mediaControl.view.findViewById<LinearLayout>(R.id.top_right_panel)
-    private fun getTopCenterPanel() = mediaControl.view.findViewById<RelativeLayout>(R.id.top_center)
+    private fun getTopCenterPanel() = mediaControl.view.findViewById<LinearLayout>(R.id.top_center)
     private fun getModalPanel() = mediaControl.view.findViewById<FrameLayout>(R.id.modal_panel)
     private fun getControlsPanel() = mediaControl.view.findViewById<RelativeLayout>(R.id.controls_panel)
     private fun getForegroundControlsPanel() = mediaControl.view.findViewById<FrameLayout>(R.id.foreground_controls_panel)


### PR DESCRIPTION
### 🏁 Goal
Position top center plugin panel correctly.

### 🖼 Screenshot

1 - After
![plugin_top_center](https://user-images.githubusercontent.com/12866746/69573835-a0cc8580-0fa5-11ea-8fb4-3b4cefd21e30.jpg)

2 - Before

![Screenshot_1574712738](https://user-images.githubusercontent.com/12866746/69574453-ec336380-0fa6-11ea-9f0d-fcc8996b46fd.png)

### ✅ How to test
1 - Create the following plugin:

```
class PluginCastButton(core: Core) : ButtonPlugin(core, name) {
    companion object : NamedType {
        override val name = "pluginCastButton"

        val entry = PluginEntry.Core(name = name, factory = { core -> PluginCastButton(core) })
    }

    override var panel: Panel = Panel.TOP

    override var position: Position = Position.CENTER

    override val resourceDrawable: Int
        get() = R.drawable.fullscreen_button

    override val idResourceDrawable: Int
        get() = R.id.fullscreen_button

    override val resourceLayout: Int
        get() = R.layout.button_plugin


    override fun onClick() {
        core.activePlayback?.stop()
    }
}
```

2 - Register this plugin in `BaseConfigPlugin`:
`Loader.register(PluginCastButton.entry)`