### PR TITLE
Fix: Media Control Show After Double Tap When Video Is Paused

### DIFF
--- a/clappr/src/main/kotlin/io/clappr/player/plugin/control/MediaControl.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/plugin/control/MediaControl.kt
@@ -60,6 +60,7 @@ open class MediaControl(core: Core, pluginName: String = name) :
     private val handler = Handler()
 
     private var lastInteractionTime = 0L
+    private var canShowMediaControlWhenPauseAfterTapInteraction = true
 
     var hideAnimationEnded = false
 
@@ -108,6 +109,7 @@ open class MediaControl(core: Core, pluginName: String = name) :
     protected val isVisible: Boolean
         get() = visibility == Visibility.VISIBLE
 
+    private val isPlaybackPlaying get() = core.activePlayback?.state == Playback.State.PLAYING
     private val isPlaybackIdle: Boolean
         get() {
             return core.activePlayback?.state == Playback.State.IDLE ||
@@ -144,7 +146,9 @@ open class MediaControl(core: Core, pluginName: String = name) :
     }
 
     open fun handleDidPauseEvent() {
-        if (!modalPanelIsOpen()) show()
+        if (!modalPanelIsOpen() && canShowMediaControlWhenPauseAfterTapInteraction) show()
+
+        canShowMediaControlWhenPauseAfterTapInteraction = true
     }
 
     open fun show(duration: Long) {
@@ -440,6 +444,7 @@ open class MediaControl(core: Core, pluginName: String = name) :
 
     inner class MediaControlDoubleTapListener : GestureDetector.OnDoubleTapListener {
         override fun onDoubleTap(event: MotionEvent?): Boolean {
+            canShowMediaControlWhenPauseAfterTapInteraction = isPlaybackPlaying
             triggerDoubleTapEvent(event)
             hide()
             return true
@@ -447,6 +452,7 @@ open class MediaControl(core: Core, pluginName: String = name) :
 
         override fun onDoubleTapEvent(e: MotionEvent?) = false
         override fun onSingleTapConfirmed(e: MotionEvent?): Boolean {
+            canShowMediaControlWhenPauseAfterTapInteraction = true
             toggleVisibility()
             return true
         }

--- a/clappr/src/test/kotlin/io/clappr/player/plugin/control/MediaControlTest.kt
+++ b/clappr/src/test/kotlin/io/clappr/player/plugin/control/MediaControlTest.kt
@@ -292,6 +292,18 @@ class MediaControlTest {
     }
 
     @Test
+    fun `should hide media control when double tap is performed`() {
+        mediaControl.visibility = UIPlugin.Visibility.VISIBLE
+        fakePlayback.fakeState = Playback.State.PLAYING
+
+        mediaControl.render()
+
+        performDoubleTap(0f, 0f)
+
+        assertEquals(UIPlugin.Visibility.HIDDEN, mediaControl.visibility)
+    }
+
+    @Test
     fun `should initialize modal panel invisible when media control plugin is created`() {
         assertEquals(View.INVISIBLE, getModalPanel().visibility)
     }

--- a/clappr/src/test/kotlin/io/clappr/player/plugin/control/MediaControlTest.kt
+++ b/clappr/src/test/kotlin/io/clappr/player/plugin/control/MediaControlTest.kt
@@ -396,6 +396,51 @@ class MediaControlTest {
     }
 
     @Test
+    fun `should send view height and width in DID_DOUBLE_TOUCH_MEDIA_CONTROL event when a double tap is performed`() {
+        val expectedViewHeight = 100
+        val expectedViewWidth = 100
+        var didDoubleTouchMediaControlBundle : Bundle? = null
+
+        Shadow.extract<ClapprShadowView>(mediaControl.view).viewHeight = expectedViewHeight
+        Shadow.extract<ClapprShadowView>(mediaControl.view).viewWidth = expectedViewWidth
+
+        mediaControl.render()
+
+        core.on(InternalEvent.DID_DOUBLE_TOUCH_MEDIA_CONTROL.value) {
+            didDoubleTouchMediaControlBundle = it
+        }
+
+        performDoubleTap(0f, 0f)
+
+        val height = didDoubleTouchMediaControlBundle?.getInt(InternalEventData.HEIGHT.value)
+        val width = didDoubleTouchMediaControlBundle?.getInt(InternalEventData.WIDTH.value)
+
+        assertEquals(expectedViewHeight, height)
+        assertEquals(expectedViewWidth, width)
+    }
+
+    @Test
+    fun `should send touch x and y axis in DID_DOUBLE_TOUCH_MEDIA_CONTROL event when a double tap is performed`() {
+        val expectedTouchX = 50f
+        val expectedTouchY = 100f
+        var didDoubleTouchMediaControlBundle : Bundle? = null
+
+        mediaControl.render()
+
+        core.on(InternalEvent.DID_DOUBLE_TOUCH_MEDIA_CONTROL.value) {
+            didDoubleTouchMediaControlBundle = it
+        }
+
+        performDoubleTap(expectedTouchX, expectedTouchY)
+
+        val x = didDoubleTouchMediaControlBundle?.getFloat(InternalEventData.TOUCH_X_AXIS.value)
+        val y = didDoubleTouchMediaControlBundle?.getFloat(InternalEventData.TOUCH_Y_AXIS.value)
+
+        assertEquals(expectedTouchX, x)
+        assertEquals(expectedTouchY, y)
+    }
+
+    @Test
     fun `should initialize modal panel invisible when media control plugin is created`() {
         assertEquals(View.INVISIBLE, getModalPanel().visibility)
     }

--- a/clappr/src/test/kotlin/io/clappr/player/plugin/control/MediaControlTest.kt
+++ b/clappr/src/test/kotlin/io/clappr/player/plugin/control/MediaControlTest.kt
@@ -1,6 +1,8 @@
 package io.clappr.player.plugin.control
 
 import android.os.Bundle
+import android.view.KeyEvent
+import android.view.MotionEvent
 import android.view.View
 import android.view.ViewGroup
 import android.widget.FrameLayout
@@ -272,6 +274,21 @@ class MediaControlTest {
         core.activePlayback?.trigger(Event.DID_PAUSE.value)
 
         assertEquals(UIPlugin.Visibility.VISIBLE, mediaControl.visibility)
+    }
+
+
+    @Test
+    fun `should not show media control when playback is paused and double tap is performed`() {
+        mediaControl.visibility = UIPlugin.Visibility.HIDDEN
+        fakePlayback.fakeState = Playback.State.PAUSED
+
+        mediaControl.render()
+
+        performDoubleTap(0f, 0f)
+
+        core.activePlayback?.trigger(Event.DID_PAUSE.value)
+
+        assertEquals(UIPlugin.Visibility.HIDDEN, mediaControl.visibility)
     }
 
     @Test
@@ -666,6 +683,13 @@ class MediaControlTest {
 
         mediaControl.show()
         assertTrue(eventTriggered)
+    }
+
+    private fun performDoubleTap(x: Float, y: Float) {
+        mediaControl.view.dispatchTouchEvent(MotionEvent.obtain(223889, 223889, KeyEvent.ACTION_DOWN, x, y, 0))
+        mediaControl.view.dispatchTouchEvent(MotionEvent.obtain(223889, 224019, KeyEvent.ACTION_UP, x, y, 0))
+        mediaControl.view.dispatchTouchEvent(MotionEvent.obtain(224069, 224069, KeyEvent.ACTION_DOWN, x, y, 0))
+        mediaControl.view.dispatchTouchEvent(MotionEvent.obtain(224069, 224191, KeyEvent.ACTION_UP, x, y, 0))
     }
 
     class FakePlayback(source: String = "aSource", mimeType: String? = null, options: Options = Options()) : Playback(source, mimeType, options, name, supportsSource) {

--- a/clappr/src/test/kotlin/io/clappr/player/plugin/control/MediaControlTest.kt
+++ b/clappr/src/test/kotlin/io/clappr/player/plugin/control/MediaControlTest.kt
@@ -272,6 +272,50 @@ class MediaControlTest {
     }
 
     @Test
+    fun `should show media control when it is hidden and single touch is performed`() {
+        mediaControl.render()
+        mediaControl.visibility = UIPlugin.Visibility.HIDDEN
+
+        performSingleTap()
+
+        assertEquals(UIPlugin.Visibility.VISIBLE, mediaControl.visibility)
+    }
+
+    @Test
+    fun `should not show media control when it is not enable but is hidden and single touch is performed`() {
+        mediaControl.render()
+        mediaControl.visibility = UIPlugin.Visibility.HIDDEN
+        mediaControl.state = Plugin.State.DISABLED
+
+        performSingleTap()
+
+        assertEquals(UIPlugin.Visibility.HIDDEN, mediaControl.visibility)
+    }
+
+    @Test
+    fun `should hide media control when it is visible and single touch is performed`() {
+        mediaControl.render()
+        fakePlayback.fakeState = Playback.State.PLAYING
+        mediaControl.visibility = UIPlugin.Visibility.VISIBLE
+
+        performSingleTap()
+
+        assertEquals(UIPlugin.Visibility.HIDDEN, mediaControl.visibility)
+    }
+
+    @Test
+    fun `should not hide media control when it is not enable but is visible and single touch is performed`() {
+        mediaControl.render()
+        mediaControl.state = Plugin.State.DISABLED
+        fakePlayback.fakeState = Playback.State.PLAYING
+        mediaControl.visibility = UIPlugin.Visibility.VISIBLE
+
+        performSingleTap()
+
+        assertEquals(UIPlugin.Visibility.VISIBLE, mediaControl.visibility)
+    }
+
+    @Test
     fun `should show media control when playback is paused`() {
         core.activePlayback?.trigger(Event.PLAYING.value)
 

--- a/clappr/src/test/kotlin/io/clappr/player/plugin/control/MediaControlTest.kt
+++ b/clappr/src/test/kotlin/io/clappr/player/plugin/control/MediaControlTest.kt
@@ -304,6 +304,21 @@ class MediaControlTest {
     }
 
     @Test
+    fun `should trigger DID_DOUBLE_TOUCH_MEDIA_CONTROL when a double tap is performed`() {
+        var didDoubleTouchMediaControlWasTriggered = false
+
+        mediaControl.render()
+
+        core.on(InternalEvent.DID_DOUBLE_TOUCH_MEDIA_CONTROL.value) {
+            didDoubleTouchMediaControlWasTriggered = true
+        }
+
+        performDoubleTap(0f, 0f)
+
+        assertTrue { didDoubleTouchMediaControlWasTriggered }
+    }
+
+    @Test
     fun `should initialize modal panel invisible when media control plugin is created`() {
         assertEquals(View.INVISIBLE, getModalPanel().visibility)
     }

--- a/clappr/src/test/kotlin/io/clappr/player/shadows/ClapprShadowView.kt
+++ b/clappr/src/test/kotlin/io/clappr/player/shadows/ClapprShadowView.kt
@@ -6,9 +6,13 @@ import org.robolectric.annotation.Implements
 import org.robolectric.shadows.ShadowView
 
 @Implements(View::class)
-class ClapprShadowView : ShadowView() {
+open class ClapprShadowView : ShadowView() {
     var viewWidth: Int = 0
+    var viewHeight: Int = 0
 
     @Implementation
     fun getWidth() = viewWidth
+
+    @Implementation
+    fun getHeight() = viewHeight
 }

--- a/clappr/src/test/kotlin/io/clappr/player/shadows/ClapprShadowViewGroup.kt
+++ b/clappr/src/test/kotlin/io/clappr/player/shadows/ClapprShadowViewGroup.kt
@@ -1,0 +1,7 @@
+package io.clappr.player.shadows
+
+import android.view.ViewGroup
+import org.robolectric.annotation.Implements
+
+@Implements(ViewGroup::class)
+open class ClapprShadowViewGroup : ClapprShadowView()


### PR DESCRIPTION
Goal
---

When a double tap is performed and the video is paused the Media Control is being shown. The Media Control should not show after a double tap.

How to Test
---

Run Unit Tests: `./gradlew clean test`