### PR TITLE
State machine enhancements on seek

### DIFF
--- a/clappr/src/main/kotlin/io/clappr/player/playback/ExoPlayerPlayback.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/playback/ExoPlayerPlayback.kt
@@ -287,6 +287,12 @@ open class ExoPlayerPlayback(
         trigger(DID_SEEK)
         triggerPositionUpdateEvent()
 
+        when(currentState) {
+            State.PLAYING -> trigger(PLAYING)
+            State.PAUSED -> trigger(DID_PAUSE)
+            State.STALLING -> trigger(STALLING)
+        }
+
         return true
     }
 

--- a/clappr/src/main/kotlin/io/clappr/player/playback/ExoPlayerPlayback.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/playback/ExoPlayerPlayback.kt
@@ -241,6 +241,7 @@ open class ExoPlayerPlayback(
         if (!canPause) return false
 
         trigger(WILL_PAUSE)
+        if (currentState == State.STALLING) trigger(STALLING)
         player?.playWhenReady = false
         return true
     }

--- a/clappr/src/test/kotlin/io/clappr/player/playback/ExoPlayerPlaybackTest.kt
+++ b/clappr/src/test/kotlin/io/clappr/player/playback/ExoPlayerPlaybackTest.kt
@@ -42,6 +42,7 @@ import java.io.IOException
 import kotlin.reflect.full.memberProperties
 import kotlin.reflect.jvm.isAccessible
 import kotlin.test.assertEquals
+import kotlin.test.fail
 
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [23], shadows = [ShadowLog::class, SubtitleViewShadow::class])
@@ -79,6 +80,87 @@ class ExoPlayerPlaybackTest {
         exoPlayerPlayBack.seek(13)
 
         assertEquals(13.0, position)
+    }
+
+    @Test
+    fun `should trigger PLAYING after seeking while on PLAYING state`() {
+        playbackOnPlayingState()
+
+        var playingWasCalled = false
+        listenObject.listenTo(exoPlayerPlayBack, PLAYING.value) {
+            playingWasCalled = true
+        }
+        listenObject.listenTo(exoPlayerPlayBack, DID_PAUSE.value) {
+            fail("DID_PAUSE should not have been called")
+        }
+        listenObject.listenTo(exoPlayerPlayBack, STALLING.value) {
+            fail("STALLING should not have been called")
+        }
+
+        exoPlayerPlayBack.seek(10)
+
+        assertEquals(playingWasCalled, true)
+    }
+
+    @Test
+    fun `should trigger DID_PAUSE after seeking while on PAUSED state`() {
+        playbackOnPausedState()
+
+        var wasCalled = false
+        listenObject.listenTo(exoPlayerPlayBack, DID_PAUSE.value) {
+            wasCalled = true
+        }
+        listenObject.listenTo(exoPlayerPlayBack, PLAYING.value) {
+            fail("PLAYING should not have been called")
+        }
+        listenObject.listenTo(exoPlayerPlayBack, STALLING.value) {
+            fail("STALLING should not have been called")
+        }
+
+        exoPlayerPlayBack.seek(10)
+
+        assertEquals(wasCalled, true)
+    }
+
+    @Test
+    fun `should trigger STALLING after seeking while on STALLING state`() {
+        playbackOnStallingState()
+
+        var wasCalled = false
+        listenObject.listenTo(exoPlayerPlayBack, STALLING.value) {
+            wasCalled = true
+        }
+
+        listenObject.listenTo(exoPlayerPlayBack, PLAYING.value) {
+            fail("PLAYING should not have been called")
+        }
+        listenObject.listenTo(exoPlayerPlayBack, DID_PAUSE.value) {
+            fail("DID_PAUSE should not have been called")
+        }
+
+        exoPlayerPlayBack.seek(10)
+
+        assertEquals(wasCalled, true)
+    }
+
+    private fun playbackOnPlayingState() {
+        exoPlayerPlayBack = ExoPlayerPlayback("supported-source.mp4")
+        exoPlayerPlayBack.eventsListener.onPlayerStateChanged(true, STATE_READY)
+        assertEquals(State.PLAYING, exoPlayerPlayBack.state)
+    }
+
+    private fun playbackOnPausedState() {
+        exoPlayerPlayBack = ExoPlayerPlayback("supported-source.mp4")
+        exoPlayerPlayBack.eventsListener.onPlayerStateChanged(true, STATE_READY)
+        exoPlayerPlayBack.eventsListener.onPlayerStateChanged(false, STATE_READY)
+        assertEquals(State.PAUSED, exoPlayerPlayBack.state)
+    }
+
+    private fun playbackOnStallingState() {
+        exoPlayerPlayBack = ExoPlayerPlayback("supported-source.mp4")
+        exoPlayerPlayBack.eventsListener.onPlayerStateChanged(true, STATE_READY)
+        exoPlayerPlayBack.eventsListener.onPlayerStateChanged(false, STATE_BUFFERING)
+        assertEquals(State.STALLING, exoPlayerPlayBack.state)
     }
 
     @Test


### PR DESCRIPTION
# Goal

- Improve the state machine to report event related events after seek (playing, did_pause and stalling)
- Improve the state machine to report stalling events after will_pause when video is paused during stalling state