### PR TITLE
Did update video resolution

### DIFF
--- a/clappr/src/main/kotlin/io/clappr/player/base/Events.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/base/Events.kt
@@ -151,6 +151,11 @@ enum class Event(val value: String) {
     DID_UPDATE_BITRATE("didUpdateBitrate"),
 
     /**
+     * Video resolution was updated
+     */
+    DID_UPDATE_VIDEO_RESOLUTION("didUpdateVideoResolution"),
+
+    /**
      * There was a video loop
      */
     DID_LOOP("didLoop"),
@@ -225,6 +230,23 @@ enum class EventData(val value: String) {
      * Bits per second
      */
     BITRATE("bitrate"),
+
+    /**
+     * [Event.DID_UPDATE_VIDEO_RESOLUTION] data
+     *
+     * Type: Int
+     *
+     * Video resolution width
+     */
+    WIDTH("width"),
+    /**
+     * [Event.DID_UPDATE_VIDEO_RESOLUTION] data
+     *
+     * Type: Int
+     *
+     * Video resolution height
+     */
+    HEIGHT("height"),
 
     /**
      * [Event.DID_RECEIVE_INPUT_KEY] data

--- a/clappr/src/main/kotlin/io/clappr/player/playback/ExoPlayerPlayback.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/playback/ExoPlayerPlayback.kt
@@ -73,6 +73,7 @@ open class ExoPlayerPlayback(
     private val mainHandler = Handler()
     val eventsListener = ExoPlayerEventsListener()
     private val bitrateEventsListener = ExoPlayerBitrateLogger()
+    private val videoResolutionListener by lazy { VideoResolutionChangeListener(this) }
     private val timeElapsedHandler = PeriodicTimeElapsedHandler(200L) { checkPeriodicUpdates() }
     private var lastBufferPercentageSent = 0.0
     private var currentState = State.NONE
@@ -299,6 +300,7 @@ open class ExoPlayerPlayback(
     protected open fun removeListeners() {
         player?.removeListener(eventsListener)
         player?.removeAnalyticsListener(bitrateEventsListener)
+        player?.removeAnalyticsListener(videoResolutionListener)
     }
 
     override fun seek(seconds: Int): Boolean {
@@ -404,6 +406,7 @@ open class ExoPlayerPlayback(
     protected open fun addListeners() {
         player?.addListener(eventsListener)
         player?.addAnalyticsListener(bitrateEventsListener)
+        player?.addAnalyticsListener(videoResolutionListener)
     }
 
     private fun buildRendererFactory() = DefaultRenderersFactory(applicationContext).apply {

--- a/clappr/src/main/kotlin/io/clappr/player/playback/VideoResolutionChangeListener.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/playback/VideoResolutionChangeListener.kt
@@ -1,0 +1,17 @@
+package io.clappr.player.playback
+
+import android.os.Bundle
+import com.google.android.exoplayer2.analytics.AnalyticsListener
+import io.clappr.player.base.Event
+import io.clappr.player.base.EventData
+import io.clappr.player.components.Playback
+
+class VideoResolutionChangeListener(private val playback: Playback) : AnalyticsListener {
+
+    override fun onVideoSizeChanged(eventTime: AnalyticsListener.EventTime?, width: Int, height: Int, unappliedRotationDegrees: Int, pixelWidthHeightRatio: Float) {
+        playback.trigger(Event.DID_UPDATE_VIDEO_RESOLUTION.value, Bundle().apply {
+            putInt(EventData.WIDTH.value, width)
+            putInt(EventData.HEIGHT.value, height)
+        })
+    }
+}

--- a/clappr/src/main/kotlin/io/clappr/player/playback/VideoResolutionChangeListener.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/playback/VideoResolutionChangeListener.kt
@@ -5,13 +5,15 @@ import com.google.android.exoplayer2.analytics.AnalyticsListener
 import io.clappr.player.base.Event
 import io.clappr.player.base.EventData
 import io.clappr.player.components.Playback
+import io.clappr.player.utils.withPayload
 
 class VideoResolutionChangeListener(private val playback: Playback) : AnalyticsListener {
 
     override fun onVideoSizeChanged(eventTime: AnalyticsListener.EventTime?, width: Int, height: Int, unappliedRotationDegrees: Int, pixelWidthHeightRatio: Float) {
-        playback.trigger(Event.DID_UPDATE_VIDEO_RESOLUTION.value, Bundle().apply {
-            putInt(EventData.WIDTH.value, width)
-            putInt(EventData.HEIGHT.value, height)
-        })
+        val userData = Bundle().withPayload(
+            EventData.WIDTH.value to width,
+            EventData.HEIGHT.value to height
+        )
+        playback.trigger(Event.DID_UPDATE_VIDEO_RESOLUTION.value, userData)
     }
 }

--- a/clappr/src/main/kotlin/io/clappr/player/utils/BundleExtensions.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/utils/BundleExtensions.kt
@@ -3,6 +3,6 @@ package io.clappr.player.utils
 import android.os.Bundle
 import java.io.Serializable
 
-fun Bundle.withPayload(vararg pairs: Pair<String, Serializable>): Bundle? = apply {
+fun Bundle.withPayload(vararg pairs: Pair<String, Serializable>): Bundle = apply {
     pairs.forEach { (key, value) -> putSerializable(key, value) }
 }

--- a/clappr/src/main/kotlin/io/clappr/player/utils/BundleExtensions.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/utils/BundleExtensions.kt
@@ -1,0 +1,8 @@
+package io.clappr.player.utils
+
+import android.os.Bundle
+import java.io.Serializable
+
+fun Bundle.withPayload(vararg pairs: Pair<String, Serializable>): Bundle? = apply {
+    pairs.forEach { (key, value) -> putSerializable(key, value) }
+}

--- a/clappr/src/test/kotlin/io/clappr/player/playback/VideoResolutionChangeListenerTest.kt
+++ b/clappr/src/test/kotlin/io/clappr/player/playback/VideoResolutionChangeListenerTest.kt
@@ -1,0 +1,41 @@
+package io.clappr.player.playback
+
+import androidx.test.core.app.ApplicationProvider
+import io.clappr.player.base.BaseObject
+import io.clappr.player.base.Options
+import io.clappr.player.components.Playback
+import io.clappr.player.playback.ExoPlayerPlayback.Companion.supportsSource
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class VideoResolutionChangeListenerTest {
+
+    @Before
+    fun setUp() {
+        BaseObject.applicationContext = ApplicationProvider.getApplicationContext()
+    }
+
+    @Test
+    fun `should trigger VIDEO_RESOLUTION_CHANGED on playback`() {
+        val playback = DummyPlayback()
+        val listener = VideoResolutionChangeListener(playback)
+
+        var width = 0
+        var height = 0
+        playback.on("didUpdateVideoResolution") {
+            width = it?.getInt("width") ?: 0
+            height = it?.getInt("height") ?: 0
+        }
+
+        listener.onVideoSizeChanged(null, 1280, 720, 0, 0.0f)
+
+        assertEquals(1280, width)
+        assertEquals(720, height)
+    }
+
+    class DummyPlayback : Playback("some-source", null, Options(), "ExoPlayerVideoSizeListenerTestPlayback", supportsSource)
+}


### PR DESCRIPTION
Goal
---

Add the capability to monitor updates to video resolution during video playback

How to test
---

Inside a plugin, Listen to the playback `DID_UPDATE_VIDEO_RESOLUTION` and log its bundle contents.
You can also force a resolution change by tempering with the emulator's bandwidth.