### PR TITLE
Replace AnalyticsListener with EventLogger

### DIFF
--- a/clappr/src/main/kotlin/io/clappr/player/playback/ExoPlayerBitrateHandler.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/playback/ExoPlayerBitrateHandler.kt
@@ -1,10 +1,10 @@
 package io.clappr.player.playback
 
 import com.google.android.exoplayer2.C
-import com.google.android.exoplayer2.analytics.AnalyticsListener
 import com.google.android.exoplayer2.analytics.AnalyticsListener.EventTime
 import com.google.android.exoplayer2.source.MediaSourceEventListener.LoadEventInfo
 import com.google.android.exoplayer2.source.MediaSourceEventListener.MediaLoadData
+import com.google.android.exoplayer2.util.EventLogger
 import io.clappr.player.bitrate.BitrateHistory
 import io.clappr.player.log.Logger
 import kotlin.math.max
@@ -40,7 +40,7 @@ class ExoPlayerBitrateHandler(
 
     fun reset() = bitrateHistory.clear()
 
-    val analyticsListener = object: AnalyticsListener {
+    val analyticsListener = object: EventLogger(null) {
         override fun onLoadCompleted(eventTime: EventTime?, loadEventInfo: LoadEventInfo?, mediaLoadData: MediaLoadData) {
             when (mediaLoadData.trackType) {
                 C.TRACK_TYPE_DEFAULT, C.TRACK_TYPE_VIDEO -> {

--- a/clappr/src/main/kotlin/io/clappr/player/playback/VideoResolutionChangeListener.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/playback/VideoResolutionChangeListener.kt
@@ -2,12 +2,13 @@ package io.clappr.player.playback
 
 import android.os.Bundle
 import com.google.android.exoplayer2.analytics.AnalyticsListener
+import com.google.android.exoplayer2.util.EventLogger
 import io.clappr.player.base.Event
 import io.clappr.player.base.EventData
 import io.clappr.player.components.Playback
 import io.clappr.player.utils.withPayload
 
-class VideoResolutionChangeListener(private val playback: Playback) : AnalyticsListener {
+class VideoResolutionChangeListener(private val playback: Playback) : EventLogger(null) {
 
     override fun onVideoSizeChanged(eventTime: AnalyticsListener.EventTime?, width: Int, height: Int, unappliedRotationDegrees: Int, pixelWidthHeightRatio: Float) {
         val userData = Bundle().withPayload(

--- a/clappr/src/test/kotlin/io/clappr/player/playback/ExoPlayerBitrateHandlerTest.kt
+++ b/clappr/src/test/kotlin/io/clappr/player/playback/ExoPlayerBitrateHandlerTest.kt
@@ -6,8 +6,11 @@ import com.google.android.exoplayer2.source.MediaSourceEventListener
 import io.clappr.player.bitrate.BitrateHistory
 import org.junit.Before
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
 import kotlin.test.assertEquals
 
+@RunWith(RobolectricTestRunner::class)
 class ExoPlayerBitrateHandlerTest {
 
     private lateinit var bitrateHistory: BitrateHistory


### PR DESCRIPTION
Goal 
---

Replace AnalyticsListener with EventLogger in order to avoid AbstractMethodError caused by java/kotlin interoperability