### PR TITLE
Set id for TextView TimeIndicator

### DIFF
--- a/clappr/src/main/kotlin/io/clappr/player/plugin/control/TimeIndicatorPlugin.kt
+++ b/clappr/src/main/kotlin/io/clappr/player/plugin/control/TimeIndicatorPlugin.kt
@@ -31,7 +31,9 @@ open class TimeIndicatorPlugin(core: Core) : MediaControl.Plugin(core, name) {
     override var panel: Panel = Panel.BOTTOM
     override var position: Position = Position.LEFT
 
-    protected val textView by lazy { LayoutInflater.from(applicationContext).inflate(R.layout.time_indicator, null) as TextView }
+    protected val textView by lazy {
+        LayoutInflater.from(applicationContext).inflate(R.layout.time_indicator, null) as TextView
+    }
 
     override val view: View?
         get() = textView

--- a/clappr/src/main/res/layout/time_indicator.xml
+++ b/clappr/src/main/res/layout/time_indicator.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <TextView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/time_indicator_textview"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
     android:gravity="center_vertical"


### PR DESCRIPTION
### Goal
- Set ID for TextView TimeIndicator in order to check visibility in instrumentation tests